### PR TITLE
Create command line shortcuts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ __pycache__/
 .coverage
 htmlcov/
 
+# Pip install files
+*.egg-info/
+
 # Custom chrome profile
 .chrome_profile/*
 
@@ -48,6 +51,3 @@ test.*
 *expected*.txt
 *output*.txt
 *sample*.txt
-
-# Future code
-*.toml

--- a/analysis/level1.py
+++ b/analysis/level1.py
@@ -176,7 +176,7 @@ async def start_level1_analysis(
     await create_level1_file(normalized, metadata)
 
 
-if __name__ == "__main__":
+def main():
     json_files = glob.glob(os.path.join("output/raw", "*.json"))
     latest_json_file = max(json_files, key=os.path.getmtime)
     data: dict = {}
@@ -186,3 +186,7 @@ if __name__ == "__main__":
     listings = data.get("listings", {})
     if metadata and listings:
         asyncio.run(start_level1_analysis(listings, metadata, None, ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/level2.py
+++ b/analysis/level2.py
@@ -153,7 +153,7 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
     )
 
 
-if __name__ == "__main__":
+def main():
     json_files = glob.glob(os.path.join("output/raw", "*.json"))
     latest_json_file = max(json_files, key=os.path.getmtime)
     data: dict = {}
@@ -164,3 +164,7 @@ if __name__ == "__main__":
     if metadata and listings:
         print(f"Loading {latest_json_file} - {len(listings)} found")
         asyncio.run(start_level2_analysis(metadata, listings, latest_json_file))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "visor-scraper"
+version = "0.3.0"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project.scripts]
+visor_scraper = "visor_scraper.scraper:main"
+kbb_collect = "analysis.kbb_collector:main"
+level1 = "analysis.level1:main"
+level2 = "analysis.level2:main"
+download = "utils.download:main"
+
+[tool.setuptools.packages.find]
+where = ["."]

--- a/utils/download.py
+++ b/utils/download.py
@@ -811,7 +811,7 @@ async def download_files(
             download_report_pdfs(listings)
 
 
-if __name__ == "__main__":
+def main():
     json_files = glob.glob(os.path.join("output/raw", "*.json"))
     latest_json_file = max(json_files, key=os.path.getmtime)
     data: dict = {}
@@ -820,3 +820,7 @@ if __name__ == "__main__":
     metadata = data.get("metadata", {})
     listings = data.get("listings", {})
     asyncio.run(download_files(listings, latest_json_file))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The following shortcuts have been made:
python -m visor_scraper.scraper [args] -> visor_scraper [args]
python -m analysis.kbb_collector -> kbb_collect
python -m analysis.level1 -> level1
python -m analysis.level1 -> level2
python -m utils.download -> download (could potentially rename to save_docs for clarity)

Another user has to use pip intsall -e . to run these locally
