### PR TITLE
210 new model cars not matching trims

### DIFF
--- a/analysis/kbb.py
+++ b/analysis/kbb.py
@@ -51,7 +51,7 @@ async def get_model_slug_map(
     variant_map = await get_variant_map(make, model, slimmed)
 
     for model_key, listings in variant_map.items():
-        if slugs and model_key in slugs:
+        if slugs and model_key in slugs and slugs[model_key]:
             relevant_slugs[model_key] = slugs[model_key]
             continue
         year = model_key[:4]

--- a/analysis/kbb.py
+++ b/analysis/kbb.py
@@ -189,13 +189,14 @@ async def get_or_fetch_national_pricing(
     pricing_data = []
     relevant_entries = get_relevant_entries(cache_entries, make, model, year)
 
+    prefix = f"{year} {make} {model} "
+
+    expected_set = set(expected_trims)
+
     all_fresh = bool(relevant_entries) and all(
-        is_natl_fresh(e) for e in relevant_entries.values()
+        is_natl_fresh(e) and key.replace(prefix, "") in expected_set
+        for key, e in relevant_entries.items()
     )
-    if expected_trims:
-        all_fresh = all_fresh and all(
-            f"{year} {make} {model} {t}" in relevant_entries for t in expected_trims
-        )
 
     if all_fresh:
         for e in relevant_entries.values():

--- a/analysis/kbb.py
+++ b/analysis/kbb.py
@@ -583,19 +583,22 @@ def find_styles_data(apollo: dict) -> dict | None:
 async def get_pricing_data(
     make: str,
     model: str,
-    listings: list[dict],
+    norm_listings: list[dict],
     variant_map: dict[str, list[dict]],
     cache: dict,
 ) -> list[TrimValuation]:
+    """
+    Get's the pricing data for the provided variants. Must use normalized listings, not the raw listings
+    """
     cache_entries = cache.setdefault("entries", {})
     slugs = cache.setdefault("model_slugs", {})
     trim_options = cache.setdefault("trim_options", {})
 
-    years = extract_years(listings)
+    years = extract_years(norm_listings)
 
     if cache_covers_all(make, list(variant_map.keys()), years, cache):
         return get_trim_valuations_from_cache(make, model, years, cache_entries)
 
     return await get_trim_valuations_from_scrape(
-        make, model, slugs, listings, trim_options, cache_entries, cache
+        make, model, slugs, norm_listings, trim_options, cache_entries, cache
     )

--- a/analysis/level2.py
+++ b/analysis/level2.py
@@ -98,7 +98,7 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
             filtered_listings.append(normalize_listing(vl))
 
     # We do not need the trim valuations, we just need to make sure the pricing data has been populated
-    _ = await get_pricing_data(make, model, listings, variant_map, cache)
+    _ = await get_pricing_data(make, model, norm_listings, variant_map, cache)
 
     valid_listings, _, _ = filter_valid_listings(
         make, model, filtered_listings, cache_entries, variant_map

--- a/analysis/level2.py
+++ b/analysis/level2.py
@@ -104,6 +104,10 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
         make, model, filtered_listings, cache_entries, variant_map
     )
 
+    if len(valid_listings) == 0:
+        print("No listings met the criteria for level 2 analysis.")
+        return
+
     # listing, deal, risk, narrative
     ratings: list[tuple[dict, str, int, list[str]]] = []
 

--- a/analysis/level2.py
+++ b/analysis/level2.py
@@ -78,7 +78,10 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
 
     cache = load_cache(PRICING_CACHE)
     cache_entries: dict = cache.setdefault("entries", {})
-    variant_map = await get_variant_map(make, model, listings)
+
+    # We must normalize listings before getting the variant map
+    norm_listings = [normalize_listing(l) for l in listings]
+    variant_map = await get_variant_map(make, model, norm_listings)
 
     # Ensure all folders exist, and if not, save the documents
     if not all(get_vehicle_dir(l) for l in listings):

--- a/analysis/normalization.py
+++ b/analysis/normalization.py
@@ -118,7 +118,7 @@ def best_kbb_model_match(
             best_score = score
             best_model = kbb_model
 
-    return best_model
+    return best_model if best_model else None
 
 
 def best_kbb_trim_match(visor_trim: str, kbb_trims: list[str]) -> str | None:

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -57,7 +57,6 @@ def cache_covers_all(
 ) -> bool:
     cache_entries = cache.get("entries", {})
     slugs = cache.get("model_slugs", {})
-    trim_options = cache.get("trim_options", {})
 
     if len(cache_entries) == 0:
         return False
@@ -69,13 +68,6 @@ def cache_covers_all(
 
         # Check model slug
         if ymm not in slugs:
-            return False
-
-        # Check trims
-        if not (
-            make_model_key in trim_options
-            and all(y in trim_options[make_model_key] for y in years)
-        ):
             return False
 
         relevant_entries = get_relevant_entries(cache_entries, make, model, year)

--- a/utils/constants/analysis.py
+++ b/utils/constants/analysis.py
@@ -7,7 +7,7 @@ KBB_CAR_PRICES_URL = "https://www.kbb.com/car-prices/"
 KBB_WHATS_MY_CAR_WORTH_URL = "https://www.kbb.com/whats-my-car-worth/"
 KBB_LOOKUP_BASE_URL = "https://kbb.com/{make}/{model}/{year}/"
 KBB_LOOKUP_STYLES_URL = KBB_LOOKUP_BASE_URL + "styles/?intent=trade-in-sell&mileage=1"
-KBB_LOOKUP_TRIM_URL = KBB_LOOKUP_BASE_URL + "/{trim}/"
+KBB_LOOKUP_TRIM_URL = KBB_LOOKUP_BASE_URL + "{trim}/"
 
 
 KBB_VARIANT_CACHE = cache_path = Path("cache") / "kbb.cache"

--- a/utils/constants/analysis.py
+++ b/utils/constants/analysis.py
@@ -6,11 +6,10 @@ from pathlib import Path
 KBB_CAR_PRICES_URL = "https://www.kbb.com/car-prices/"
 KBB_WHATS_MY_CAR_WORTH_URL = "https://www.kbb.com/whats-my-car-worth/"
 KBB_LOOKUP_BASE_URL = "https://kbb.com/{make}/{model}/{year}/"
-KBB_LOOKUP_STYLES_URL = KBB_LOOKUP_BASE_URL + "styles/?intent=trade-in-sell&mileage=1"
 KBB_LOOKUP_TRIM_URL = KBB_LOOKUP_BASE_URL + "{trim}/"
 
 
-KBB_VARIANT_CACHE = cache_path = Path("cache") / "kbb.cache"
+KBB_VARIANT_CACHE = Path("cache") / "kbb.cache"
 PRICING_CACHE = Path("cache") / "pricing.cache"
 ANALYSIS_CACHE = Path("cache") / "analysis.cache"
 CACHE_TTL = timedelta(days=7)

--- a/visor_scraper/helpers.py
+++ b/visor_scraper/helpers.py
@@ -12,7 +12,20 @@ from utils.constants import *
 
 
 def metadata_years(years: list[str]) -> str:
-    vals = sorted({int(y) for y in years})
+    if years is None:
+        return ""
+
+    if not isinstance(years, (list, tuple)):
+        years = [years]
+
+    vals = sorted(
+        {
+            int(str(y).strip().strip('"').strip("'"))
+            for y in years
+            if y is not None and str(y).strip().strip('"').strip("'").isdigit()
+        }
+    )
+
     if not vals:
         return ""
 


### PR DESCRIPTION
### Summary of changes:

- Major changes:
  - Completely removed pinging KBB for trim options. We now pull the body styles straight from KBB's model page (kbb.py)
  - Instead of searching for cars through an  API requests, we use the models from the KBB cache and normalize them (kbb.py)
  - When collecting the pricing per year, we create a set of unique trims for that year that we compare to the trims retrieved from get_or_fetch_national_pricing. We use that list find the best matches from the trims from the national data, and then collect the local FPP when they match (kbb.py)
  - Simplified best_kbb_model_match by tokenizing the trim, trim version, and dealer url and scoring that way (normalization.py)
- Minor changes:
  - Added retry logic in get_or_fetch_national_pricing and changed how it is being collected (kbb.py)
  - Added a console message if no listings can be used for level 2 analysis (level2.py)
  - Removed unused and modified analysis constants (constants.analysis.py)
- Bug fixes:
  - Fixed casting issue when only one year was selected in metadata_years (helpers.py)