### PR TITLE
Level 3 baseline code

### DIFF
--- a/analysis/analysis_utils.py
+++ b/analysis/analysis_utils.py
@@ -3,15 +3,7 @@ import asyncio, glob, json, os, time
 
 from pathlib import Path
 
-from analysis.kbb import get_pricing_data
-from analysis.normalization import (
-    filter_valid_listings,
-    get_variant_map,
-    normalize_listing,
-)
-from analysis.analysis_utils import check_missing_docs, get_report_dir, get_vehicle_dir
 
-from utils.cache import load_cache
 from utils.common import make_string_url_safe
 from utils.constants import *
 from utils.download import download_files, download_report_pdfs
@@ -165,37 +157,3 @@ def check_missing_docs(listings: list[dict]):
     if missing_reports:
         print(f"Downloading reports for {len(missing_reports)} listings...")
         download_report_pdfs(missing_reports)
-
-
-async def prepare_advanced_analysis(
-    make: str, model: str, listings: list[dict], filename: str
-) -> tuple[list[dict], dict]:
-    cache = load_cache(PRICING_CACHE)
-    cache_entries: dict = cache.setdefault("entries", {})
-
-    # We must normalize listings before getting the variant map
-    norm_listings = [normalize_listing(l) for l in listings]
-    variant_map = await get_variant_map(make, model, norm_listings)
-
-    # Ensure all folders exist, and if not, save the documents
-    if not all(get_vehicle_dir(l) for l in listings):
-        await download_files(listings, filename)
-
-    # Check for missings documents (pdfs, html)
-    check_missing_docs(listings)
-
-    # Filter out only the listings that have a valid report
-    filtered_listings = []
-    for vl in listings:
-        report = get_report_dir(vl)
-        if report and report.exists():
-            filtered_listings.append(normalize_listing(vl))
-
-    # We do not need the trim valuations, we just need to make sure the pricing data has been populated
-    _ = await get_pricing_data(make, model, norm_listings, variant_map, cache)
-
-    valid_listings, _, _ = filter_valid_listings(
-        make, model, filtered_listings, cache_entries, variant_map
-    )
-
-    return (valid_listings, cache_entries)

--- a/analysis/analysis_utils.py
+++ b/analysis/analysis_utils.py
@@ -157,3 +157,7 @@ def check_missing_docs(listings: list[dict]):
     if missing_reports:
         print(f"Downloading reports for {len(missing_reports)} listings...")
         download_report_pdfs(missing_reports)
+
+
+def is_dollar_amount(s: str) -> bool:
+    return bool(DOLLAR_AMOUNT_RE.match(s.strip()))

--- a/analysis/analysis_utils.py
+++ b/analysis/analysis_utils.py
@@ -1,5 +1,20 @@
+import asyncio, glob, json, os, time
+
+
+from pathlib import Path
+
+from analysis.kbb import get_pricing_data
+from analysis.normalization import (
+    filter_valid_listings,
+    get_variant_map,
+    normalize_listing,
+)
+from analysis.analysis_utils import check_missing_docs, get_report_dir, get_vehicle_dir
+
+from utils.cache import load_cache
 from utils.common import make_string_url_safe
 from utils.constants import *
+from utils.download import download_files, download_report_pdfs
 from utils.models import TrimValuation
 
 
@@ -117,3 +132,70 @@ def get_trim_valuations_from_cache(
 
             trim_valuations.append(TrimValuation.from_dict(entry))
     return trim_valuations
+
+
+def get_vehicle_dir(listing: dict) -> Path | None:
+    title = listing.get("title")
+    vin = listing.get("vin")
+    if title is None or vin is None:
+        return None
+    path = Path(DOC_PATH) / title / vin
+    return path if path.is_dir() else None
+
+
+def get_report_dir(listing: dict) -> Path | None:
+    dir = get_vehicle_dir(listing)
+    return dir / "carfax.html" if dir else None
+
+
+def check_missing_docs(listings: list[dict]):
+    # Check to see if files exists
+    missing_reports = []
+    for l in listings:
+        dir = get_vehicle_dir(l)
+        if dir is None:
+            continue
+        html = dir / "carfax.html"
+        pdf = dir / "carfax.pdf"
+
+        carfax_url = l.get("additional_docs", {}).get("carfax_url", "Unavailable")
+        if carfax_url != "Unavailable" and not pdf.exists() and not html.exists():
+            missing_reports.append(l)
+
+    if missing_reports:
+        print(f"Downloading reports for {len(missing_reports)} listings...")
+        download_report_pdfs(missing_reports)
+
+
+async def prepare_advanced_analysis(
+    make: str, model: str, listings: list[dict], filename: str
+) -> tuple[list[dict], dict]:
+    cache = load_cache(PRICING_CACHE)
+    cache_entries: dict = cache.setdefault("entries", {})
+
+    # We must normalize listings before getting the variant map
+    norm_listings = [normalize_listing(l) for l in listings]
+    variant_map = await get_variant_map(make, model, norm_listings)
+
+    # Ensure all folders exist, and if not, save the documents
+    if not all(get_vehicle_dir(l) for l in listings):
+        await download_files(listings, filename)
+
+    # Check for missings documents (pdfs, html)
+    check_missing_docs(listings)
+
+    # Filter out only the listings that have a valid report
+    filtered_listings = []
+    for vl in listings:
+        report = get_report_dir(vl)
+        if report and report.exists():
+            filtered_listings.append(normalize_listing(vl))
+
+    # We do not need the trim valuations, we just need to make sure the pricing data has been populated
+    _ = await get_pricing_data(make, model, norm_listings, variant_map, cache)
+
+    valid_listings, _, _ = filter_valid_listings(
+        make, model, filtered_listings, cache_entries, variant_map
+    )
+
+    return (valid_listings, cache_entries)

--- a/analysis/kbb.py
+++ b/analysis/kbb.py
@@ -247,7 +247,7 @@ async def populate_pricing_for_year(
             )
         else:
             if not natl_fpp or natl_fpp == "TBD":
-                print(f"ℹ️  No national pricing data for {kbb_trim}; saving MSRP only")
+                return f"No national pricing data for {kbb_trim}"
 
         entry = cache_entries.setdefault(kbb_trim, {})
 

--- a/analysis/kbb.py
+++ b/analysis/kbb.py
@@ -135,7 +135,10 @@ async def get_or_fetch_national_pricing(
         try:
             body = await page.inner_text("body")
             if "We're sorry, our experts haven't reviewed this car yet" in body:
-                return pricing_data, f"Unable to find table for pricing: {natl_url}"
+                return (
+                    pricing_data,
+                    f"KBB does not have data for this trim: {year} {make} {model}",
+                )
             rows_locator = page.locator("table.css-lb65co tbody tr")
             await rows_locator.first.wait_for(timeout=5000)
             rows = await rows_locator.all()
@@ -145,7 +148,10 @@ async def get_or_fetch_national_pricing(
                 await table.first.wait_for(timeout=5000)
                 rows = await table.all()
             except TimeoutError as t2:
-                return pricing_data, f"Unable to find table for pricing: {natl_url}"
+                return (
+                    pricing_data,
+                    f"KBB does not have data for this trim: {year} {make} {model}",
+                )
 
         # Collect the pricing data before attempting to get FMV, otherwise page context gets
         # overwritten and Playwright will throw an error

--- a/analysis/kbb.py
+++ b/analysis/kbb.py
@@ -247,7 +247,7 @@ async def populate_pricing_for_year(
             )
         else:
             if not natl_fpp or natl_fpp == "TBD":
-                return f"No national pricing data for {kbb_trim}"
+                error = f"No national pricing data for {kbb_trim}"
 
         entry = cache_entries.setdefault(kbb_trim, {})
 

--- a/analysis/kbb.py
+++ b/analysis/kbb.py
@@ -23,6 +23,7 @@ from analysis.analysis_utils import (
     extract_years,
     get_relevant_entries,
     get_trim_valuations_from_cache,
+    is_dollar_amount,
     is_trim_version_valid,
     to_int,
 )
@@ -177,6 +178,10 @@ async def get_or_fetch_national_pricing(
                 table_trim = (await tds[0].inner_text()).strip()
                 msrp = (await tds[1].inner_text()).strip()
                 natl_fpp = None
+
+            # Skips other placeholder values
+            if not is_dollar_amount(msrp) and msrp != "TBD":
+                continue
 
             pricing_data.append(
                 (

--- a/analysis/kbb.py
+++ b/analysis/kbb.py
@@ -14,7 +14,6 @@ from tqdm import tqdm
 
 from utils.cache import (
     cache_covers_all,
-    get_relevant_entries,
     is_entry_fresh,
     is_natl_fresh,
     save_cache,
@@ -22,6 +21,7 @@ from utils.cache import (
 from analysis.normalization import best_kbb_trim_match, get_variant_map
 from analysis.analysis_utils import (
     extract_years,
+    get_relevant_entries,
     get_trim_valuations_from_cache,
     is_trim_version_valid,
     to_int,
@@ -508,8 +508,11 @@ async def get_pricing_data(
     slugs = cache.setdefault("model_slugs", {})
 
     years = extract_years(norm_listings)
+    relevant_entries: dict[str, dict[str, dict]] = {}
+    for y in years:
+        relevant_entries[y] = get_relevant_entries(cache_entries, make, model, y)
 
-    if cache_covers_all(make, list(variant_map.keys()), years, cache):
+    if cache_covers_all(list(variant_map.keys()), relevant_entries, cache):
         return get_trim_valuations_from_cache(make, model, years, cache_entries)
 
     return await get_trim_valuations_from_scrape(

--- a/analysis/level1.py
+++ b/analysis/level1.py
@@ -20,43 +20,30 @@ from analysis.scoring import (
     rate_risk_level1,
     rate_uncertainty,
 )
+from analysis.workflow import prepare_level1_analysis
 
 from utils.constants import PRICING_CACHE
 from utils.models import CarListing, DealBin, TrimValuation
 
 
 async def create_level1_file(listings: list[dict], metadata: dict):
-    cache = load_cache(PRICING_CACHE)
-    cache_entries: dict = cache.setdefault("entries", {})
-
-    make = metadata["vehicle"]["make"]
-    model = metadata["vehicle"]["model"]
-
-    variant_map = await get_variant_map(make, model, listings)
-
-    trim_valuations: list[TrimValuation] = await get_pricing_data(
-        make, model, listings, variant_map, cache
-    )
+    ctx = await prepare_level1_analysis(metadata, listings)
 
     no_price_bin = DealBin(category="No Price", listings=[], count=0)
     all_listings: list[CarListing] = []
     seen_ids: set[str] = set()  # guard if input has dupes
 
-    valid_data, skipped_listings, skip_summary = filter_valid_listings(
-        make, model, listings, cache_entries, variant_map
-    )
-
-    for item in valid_data:
+    for item in ctx.valid_listings:
         listing = item["listing"]
         cache_key = item["cache_key"]
         year = item["year"]
         base_trim = item["base_trim"]
 
-        msrp = int(cache_entries[cache_key].get("msrp"))
-        fpp_natl = int(cache_entries[cache_key].get("fpp_natl") or 0)
-        fpp_local = int(cache_entries[cache_key].get("fpp_local") or 0)
-        fmr_high = int(cache_entries[cache_key].get("fmr_high") or 0)
-        fmv = int(cache_entries[cache_key].get("fmv") or 0)
+        msrp = int(ctx.cache_entries[cache_key].get("msrp") or 0)
+        fpp_natl = int(ctx.cache_entries[cache_key].get("fpp_natl") or 0)
+        fpp_local = int(ctx.cache_entries[cache_key].get("fpp_local") or 0)
+        fmr_high = int(ctx.cache_entries[cache_key].get("fmr_high") or 0)
+        fmv = int(ctx.cache_entries[cache_key].get("fmv") or 0)
 
         price = int(listing.get("price") or 0)
         best_comparison = determine_best_price(price, fpp_local, fpp_natl, fmv, [])
@@ -73,8 +60,8 @@ async def create_level1_file(listings: list[dict], metadata: dict):
             id=listing["id"],
             vin=listing["vin"],
             year=int(year),
-            make=make,
-            model=model,
+            make=ctx.make,
+            model=ctx.model,
             trim=base_trim,
             trim_version=listing["trim_version"],
             title=listing["title"],
@@ -116,12 +103,12 @@ async def create_level1_file(listings: list[dict], metadata: dict):
     cond_dist_total = compute_condition_distribution_total(all_listings)
 
     analysis_json = to_level1_json(
-        make=make,
-        model=model,
+        make=ctx.make,
+        model=ctx.model,
         sort=metadata["filters"]["sort"],  # already available in start_level1_analysis
         deal_bins=deal_bins,
         crosstab=crosstab,
-        skipped_listings=skipped_listings,
+        skipped_listings=ctx.skipped_listings,
     )
     analysis_json["condition_distribution"] = cond_dist_total
 
@@ -129,27 +116,27 @@ async def create_level1_file(listings: list[dict], metadata: dict):
 
     # Only pass along the entries from the quicklist, not the entire cache
     quicklist = sorted(
-        {l.cache_key for l in all_listings if l.cache_key in cache_entries}
+        {l.cache_key for l in all_listings if l.cache_key in ctx.cache_entries}
     )
     visible_entries = {
-        k: TrimValuation.from_dict({**cache_entries[k], "kbb_trim": k})
+        k: TrimValuation.from_dict({**ctx.cache_entries[k], "kbb_trim": k})
         for k in quicklist
     }
 
     # Output skipped listing reasons
     skip_messages: list[str] = []
     # print("The following models have been skipped for these reasons:")
-    for title, reasons in sorted(skip_summary.items()):
+    for title, reasons in sorted(ctx.skip_summary.items()):
         for reason, count in reasons.items():
             # print(f"  - {title}: {reason} ({count})")
             skip_messages.append(f"{title}: {reason} ({count})")
 
     await render_level1_pdf(
-        make,
-        model,
+        ctx.make,
+        ctx.model,
         visible_entries,
         all_listings,
-        trim_valuations,
+        ctx.trim_valuations,
         deal_bins,
         great_bin,
         good_bin,

--- a/analysis/level2.py
+++ b/analysis/level2.py
@@ -1,31 +1,16 @@
 import asyncio, glob, json, os, time
 
-from pathlib import Path
-
-from analysis.kbb import get_pricing_data
-from analysis.normalization import (
-    filter_valid_listings,
-    get_variant_map,
-    normalize_listing,
-)
+from analysis.analysis_utils import get_report_dir
+from analysis.reporting import render_level2_pdf
 from analysis.scoring import (
     adjust_deal_for_risk,
     classify_deal_rating,
     determine_best_price,
     rate_risk_level2,
 )
-from analysis.reporting import render_level2_pdf
-from analysis.analysis_utils import (
-    check_missing_docs,
-    get_report_dir,
-    get_vehicle_dir,
-    prepare_advanced_analysis,
-)
+from analysis.workflow import prepare_level2_analysis
 
-from utils.cache import load_cache
 from utils.carfax_parser import get_carfax_data
-from utils.constants import *
-from utils.download import download_files, download_report_pdfs
 from utils.models import CarfaxData
 
 
@@ -45,14 +30,9 @@ def report_stats(label: str, values: list[float]):
 
 
 async def start_level2_analysis(metadata: dict, listings: list[dict], filename: str):
-    make = metadata["vehicle"]["make"]
-    model = metadata["vehicle"]["model"]
+    ctx = await prepare_level2_analysis(metadata, listings, filename)
 
-    valid_listings, cache_entries = await prepare_advanced_analysis(
-        make, model, listings, filename
-    )
-
-    if len(valid_listings) == 0:
+    if len(ctx.valid_listings) == 0:
         print("No listings met the criteria for level 2 analysis.")
         return None
 
@@ -60,7 +40,7 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
     ratings: list[tuple[dict, str, int, list[str]]] = []
 
     # Extract Carfax report
-    for vl in sorted(valid_listings, key=lambda x: x["listing"]["id"]):
+    for vl in sorted(ctx.valid_listings, key=lambda x: x["listing"]["id"]):
         listing: dict = vl["listing"]
         cache_key = vl["cache_key"]
 
@@ -72,10 +52,10 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
         narrative: list[str] = []
 
         price = int(listing.get("price", 0))
-        fpp_natl = int(cache_entries[cache_key].get("fpp_natl") or 0)
-        fpp_local = int(cache_entries[cache_key].get("fpp_local") or 0)
-        fmr_high = int(cache_entries[cache_key].get("fmr_high") or 0)
-        fmv = int(cache_entries[cache_key].get("fmv") or 0)
+        fpp_natl = int(ctx.cache_entries[cache_key].get("fpp_natl") or 0)
+        fpp_local = int(ctx.cache_entries[cache_key].get("fpp_local") or 0)
+        fmr_high = int(ctx.cache_entries[cache_key].get("fmr_high") or 0)
+        fmv = int(ctx.cache_entries[cache_key].get("fmv") or 0)
 
         if not (fpp_natl and fpp_local and fmv):
             narrative.append(
@@ -104,7 +84,7 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
         ratings.append((listing, deal, risk, narrative))
 
     await render_level2_pdf(
-        make, model, len(listings), len(valid_listings), ratings, metadata
+        ctx.make, ctx.model, len(listings), len(ctx.valid_listings), ratings, metadata
     )
 
 

--- a/analysis/level2.py
+++ b/analysis/level2.py
@@ -2,7 +2,6 @@ import asyncio, glob, json, os, time
 
 from pathlib import Path
 
-from utils.cache import load_cache
 from analysis.kbb import get_pricing_data
 from analysis.normalization import (
     filter_valid_listings,
@@ -16,7 +15,14 @@ from analysis.scoring import (
     rate_risk_level2,
 )
 from analysis.reporting import render_level2_pdf
+from analysis.analysis_utils import (
+    check_missing_docs,
+    get_report_dir,
+    get_vehicle_dir,
+    prepare_advanced_analysis,
+)
 
+from utils.cache import load_cache
 from utils.carfax_parser import get_carfax_data
 from utils.constants import *
 from utils.download import download_files, download_report_pdfs
@@ -38,75 +44,17 @@ def report_stats(label: str, values: list[float]):
     )
 
 
-def get_vehicle_dir(listing: dict) -> Path | None:
-    title = listing.get("title")
-    vin = listing.get("vin")
-    if title is None or vin is None:
-        return None
-    path = Path(DOC_PATH) / title / vin
-    return path if path.is_dir() else None
-
-
-def get_report_dir(listing: dict) -> Path | None:
-    dir = get_vehicle_dir(listing)
-    # TODO: add auto-check
-    return dir / "carfax.html" if dir else None
-
-
-def check_missing_docs(listings: list[dict]):
-    # Check to see if files exists
-    missing_reports = []
-    for l in listings:
-        dir = get_vehicle_dir(l)
-        if dir is None:
-            continue
-        html = dir / "carfax.html"
-        pdf = dir / "carfax.pdf"
-
-        carfax_url = l.get("additional_docs", {}).get("carfax_url", "Unavailable")
-        if carfax_url != "Unavailable" and not pdf.exists() and not html.exists():
-            missing_reports.append(l)
-
-    if missing_reports:
-        print(f"Downloading reports for {len(missing_reports)} listings...")
-        download_report_pdfs(missing_reports)
-
-
 async def start_level2_analysis(metadata: dict, listings: list[dict], filename: str):
     make = metadata["vehicle"]["make"]
     model = metadata["vehicle"]["model"]
 
-    cache = load_cache(PRICING_CACHE)
-    cache_entries: dict = cache.setdefault("entries", {})
-
-    # We must normalize listings before getting the variant map
-    norm_listings = [normalize_listing(l) for l in listings]
-    variant_map = await get_variant_map(make, model, norm_listings)
-
-    # Ensure all folders exist, and if not, save the documents
-    if not all(get_vehicle_dir(l) for l in listings):
-        await download_files(listings, filename)
-
-    # Check for missings documents (pdfs, html)
-    check_missing_docs(listings)
-
-    # Filter out only the listings that have a valid report
-    filtered_listings = []
-    for vl in listings:
-        report = get_report_dir(vl)
-        if report and report.exists():
-            filtered_listings.append(normalize_listing(vl))
-
-    # We do not need the trim valuations, we just need to make sure the pricing data has been populated
-    _ = await get_pricing_data(make, model, norm_listings, variant_map, cache)
-
-    valid_listings, _, _ = filter_valid_listings(
-        make, model, filtered_listings, cache_entries, variant_map
+    valid_listings, cache_entries = await prepare_advanced_analysis(
+        make, model, listings, filename
     )
 
     if len(valid_listings) == 0:
         print("No listings met the criteria for level 2 analysis.")
-        return
+        return None
 
     # listing, deal, risk, narrative
     ratings: list[tuple[dict, str, int, list[str]]] = []

--- a/analysis/level2.py
+++ b/analysis/level2.py
@@ -1,5 +1,7 @@
 import asyncio, glob, json, os, time
 
+from pathlib import Path
+
 from analysis.analysis_utils import get_report_dir
 from analysis.reporting import render_level2_pdf
 from analysis.scoring import (
@@ -32,7 +34,7 @@ def report_stats(label: str, values: list[float]):
 async def start_level2_analysis(metadata: dict, listings: list[dict], filename: str):
     ctx = await prepare_level2_analysis(metadata, listings, filename)
 
-    if len(ctx.valid_listings) == 0:
+    if len(ctx.listings) == 0:
         print("No listings met the criteria for level 2 analysis.")
         return None
 
@@ -40,22 +42,23 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
     ratings: list[tuple[dict, str, int, list[str]]] = []
 
     # Extract Carfax report
-    for vl in sorted(ctx.valid_listings, key=lambda x: x["listing"]["id"]):
-        listing: dict = vl["listing"]
-        cache_key = vl["cache_key"]
+    for lc in sorted(ctx.listings, key=lambda x: str(x.listing.get("id", ""))):
+        listing = lc.listing
+        price_val = listing.get("price")
+        if price_val is None:
+            continue
 
-        full_listing = next(l for l in listings if l.get("id") == listing.get("id"))
-        report = get_report_dir(full_listing)
-        if report is None or not report.exists() or listing.get("price") is None:
+        report = Path(lc.report_path) if lc.report_path else None
+        if report is None or not report.exists():
             continue
 
         narrative: list[str] = []
 
-        price = int(listing.get("price", 0))
-        fpp_natl = int(ctx.cache_entries[cache_key].get("fpp_natl") or 0)
-        fpp_local = int(ctx.cache_entries[cache_key].get("fpp_local") or 0)
-        fmr_high = int(ctx.cache_entries[cache_key].get("fmr_high") or 0)
-        fmv = int(ctx.cache_entries[cache_key].get("fmv") or 0)
+        price = int(price_val)
+        fpp_natl = int(lc.pricing.fpp_natl or 0)
+        fpp_local = int(lc.pricing.fpp_local or 0)
+        fmr_high = int(lc.pricing.fmr_high or 0)
+        fmv = int(lc.pricing.fmv or 0)
 
         if not (fpp_natl and fpp_local and fmv):
             narrative.append(
@@ -68,6 +71,7 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
         best_comparison = determine_best_price(
             price, fpp_local, fpp_natl, fmv, narrative
         )
+
         deal, midpoint, increment, percent = classify_deal_rating(
             price, best_comparison, fmv, fpp_local, fmr_high
         )
@@ -79,12 +83,19 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
 
         # Risk ratings and deal adjustment
         carfax: CarfaxData = get_carfax_data(report)
+        lc.carfax = carfax
+
         risk = rate_risk_level2(carfax, listing, narrative)
+        lc.risk_score = risk
+
         deal = adjust_deal_for_risk(deal, risk, narrative)
+        lc.deal_rating = deal
+        lc.narrative = narrative
+
         ratings.append((listing, deal, risk, narrative))
 
     await render_level2_pdf(
-        ctx.make, ctx.model, len(listings), len(ctx.valid_listings), ratings, metadata
+        ctx.make, ctx.model, len(listings), len(ctx.listings), ratings, metadata
     )
 
 

--- a/analysis/level3.py
+++ b/analysis/level3.py
@@ -1,0 +1,61 @@
+import asyncio, glob, json, os, time
+
+
+from pathlib import Path
+
+from analysis.kbb import get_pricing_data
+from analysis.normalization import (
+    filter_valid_listings,
+    get_variant_map,
+    normalize_listing,
+)
+from analysis.scoring import (
+    adjust_deal_for_risk,
+    classify_deal_rating,
+    determine_best_price,
+    rate_risk_level2,
+)
+from analysis.reporting import render_level2_pdf
+from analysis.analysis_utils import (
+    check_missing_docs,
+    get_report_dir,
+    get_vehicle_dir,
+    prepare_advanced_analysis,
+)
+
+
+from utils.cache import load_cache
+from utils.carfax_parser import get_carfax_data
+from utils.constants import *
+from utils.download import download_files, download_report_pdfs
+from utils.models import CarfaxData
+
+
+async def start_level3_analysis(metadata: dict, listings: list[dict], filename: str):
+    make = metadata["vehicle"]["make"]
+    model = metadata["vehicle"]["model"]
+
+    valid_listings, cache_entries = await prepare_advanced_analysis(
+        make, model, listings, filename
+    )
+
+    if len(valid_listings) == 0:
+        print("No listings met the criteria for level 2 analysis.")
+        return None
+
+
+def main():
+    json_files = glob.glob(os.path.join("output/raw", "*.json"))
+    latest_json_file = max(json_files, key=os.path.getmtime)
+    data: dict = {}
+    with open(latest_json_file, "r") as file:
+        data = json.load(file)
+    metadata = data.get("metadata", {})
+    listings = data.get("listings", {})
+    if metadata and listings:
+        print(f"Loading {latest_json_file} - {len(listings)} found")
+        asyncio.run(start_level3_analysis(metadata, listings, latest_json_file))
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/level3.py
+++ b/analysis/level3.py
@@ -15,33 +15,69 @@ from analysis.scoring import (
     determine_best_price,
     rate_risk_level2,
 )
-from analysis.reporting import render_level2_pdf
-from analysis.analysis_utils import (
-    check_missing_docs,
+from analysis.workflow import (
     get_report_dir,
-    get_vehicle_dir,
-    prepare_advanced_analysis,
+    prepare_level3_analysis,
 )
 
 
-from utils.cache import load_cache
 from utils.carfax_parser import get_carfax_data
-from utils.constants import *
-from utils.download import download_files, download_report_pdfs
 from utils.models import CarfaxData
 
 
 async def start_level3_analysis(metadata: dict, listings: list[dict], filename: str):
-    make = metadata["vehicle"]["make"]
-    model = metadata["vehicle"]["model"]
+    ctx = await prepare_level3_analysis(metadata, listings, filename)
 
-    valid_listings, cache_entries = await prepare_advanced_analysis(
-        make, model, listings, filename
-    )
-
-    if len(valid_listings) == 0:
-        print("No listings met the criteria for level 2 analysis.")
+    if len(ctx.valid_listings) == 0:
+        print("No listings met the criteria for level 3 analysis.")
         return None
+
+    # listing, deal, risk, narrative
+    ratings: list[tuple[dict, str, int, list[str]]] = []
+
+    # Extract Carfax report
+    for vl in sorted(ctx.valid_listings, key=lambda x: x["listing"]["id"]):
+        listing: dict = vl["listing"]
+        cache_key = vl["cache_key"]
+
+        full_listing = next(l for l in listings if l.get("id") == listing.get("id"))
+        report = get_report_dir(full_listing)
+        if report is None or not report.exists() or listing.get("price") is None:
+            continue
+
+        narrative: list[str] = []
+
+        price = int(listing.get("price", 0))
+        fpp_natl = int(ctx.cache_entries[cache_key].get("fpp_natl") or 0)
+        fpp_local = int(ctx.cache_entries[cache_key].get("fpp_local") or 0)
+        fmr_high = int(ctx.cache_entries[cache_key].get("fmr_high") or 0)
+        fmv = int(ctx.cache_entries[cache_key].get("fmv") or 0)
+
+        if not (fpp_natl and fpp_local and fmv):
+            narrative.append(
+                "Unable to provide ratings for this vehicle: no pricing data is available for this vehicle."
+            )
+            continue
+
+        # Initial deal ratings
+        narrative.append(f"This vehicle is being listed at ${price}.")
+        best_comparison = determine_best_price(
+            price, fpp_local, fpp_natl, fmv, narrative
+        )
+        deal, midpoint, increment, percent = classify_deal_rating(
+            price, best_comparison, fmv, fpp_local, fmr_high
+        )
+        narrative.append(
+            f"Deal bins are set at ${increment * 2} ({percent * 200}%) in size, placing the Fair midpoint at ${midpoint}."
+        )
+        if deal == "Great" and midpoint and price < midpoint - increment * 3:
+            deal = "Suspicious"
+
+        # Risk ratings and deal adjustment
+        carfax: CarfaxData = get_carfax_data(report)
+        risk = rate_risk_level2(carfax, listing, narrative)
+        deal = adjust_deal_for_risk(deal, risk, narrative)
+        ratings.append((listing, deal, risk, narrative))
 
 
 def main():

--- a/analysis/scoring.py
+++ b/analysis/scoring.py
@@ -50,7 +50,11 @@ def rate_uncertainty(listing) -> str:
 
 
 def determine_best_price(
-    price: int, fpp_local: int, fpp_natl: int, fmv: int, narrative: list[str]
+    price: int,
+    fpp_local: int,
+    fpp_natl: int,
+    fmv: int,
+    narrative: Optional[list[str]] = None,
 ) -> int:
     source: str = ""
     reason: str = ""
@@ -75,11 +79,12 @@ def determine_best_price(
         source = "FMV"
         reason = "no national or local FPP could be found"
 
-    narrative.append(f"{source} was used as the comparison value because {reason}.")
-    if source == "FMV":
-        narrative.append(
-            "As FMV is a measure of how much a car would be sold privately, the following ratings may be inaccurate."
-        )
+    if narrative is not None:
+        narrative.append(f"{source} was used as the comparison value because {reason}.")
+        if source == "FMV":
+            narrative.append(
+                "As FMV is a measure of how much a car would be sold privately, the following ratings may be inaccurate."
+            )
 
     return value
 
@@ -176,17 +181,21 @@ def rate_risk_level1(listing, price, compare_value) -> str:
         return "Low"
 
 
-def adjust_deal_for_risk(base_bin: str, risk: float, narrative: list[str]) -> str:
+def adjust_deal_for_risk(
+    base_bin: str, risk: float, narrative: Optional[list[str]] = None
+) -> str:
     """
     Adjusts deal grading for level 2 based on the risk.
     """
     if base_bin == "Suspicious":
         if risk > 5:
-            narrative.append(
-                "Deal rating has been downgraded to Bad due to risk and suspicious pricing."
-            )
+            if narrative is not None:
+                narrative.append(
+                    "Deal rating has been downgraded to Bad due to risk and suspicious pricing."
+                )
             return "Bad"
-        narrative.append("Deal is set as Suspicious due to extreme pricing.")
+        if narrative is not None:
+            narrative.append("Deal is set as Suspicious due to extreme pricing.")
         return "Suspicious"
 
     idx = DEAL_ORDER.index(base_bin)
@@ -199,26 +208,30 @@ def adjust_deal_for_risk(base_bin: str, risk: float, narrative: list[str]) -> st
     elif risk <= 8:
         shift = 3
     else:
-        narrative.append(
-            f"Originally rated {base_bin} based on price alone, but shifted to Bad due to extreme risk."
-        )
+        if narrative is not None:
+            narrative.append(
+                f"Originally rated {base_bin} based on price alone, but shifted to Bad due to extreme risk."
+            )
         return "Bad"
 
     new_deal = DEAL_ORDER[min(idx + shift, len(DEAL_ORDER) - 1)]
 
-    if shift == 0:
-        narrative.append(
-            f"Deal rating is fixed at {base_bin} based on price and {"low" if risk else "no"} risk factors."
-        )
-    else:
-        narrative.append(
-            f"Originally rated {base_bin} based on price alone, but is now downgraded to {new_deal} due to risk factors."
-        )
+    if narrative is not None:
+        if shift == 0:
+            narrative.append(
+                f"Deal rating is fixed at {base_bin} based on price and {"low" if risk else "no"} risk factors."
+            )
+        else:
+            narrative.append(
+                f"Originally rated {base_bin} based on price alone, but is now downgraded to {new_deal} due to risk factors."
+            )
 
     return new_deal
 
 
-def rate_risk_level2(carfax: CarfaxData, listing: dict, narrative: list[str]) -> int:
+def rate_risk_level2(
+    carfax: CarfaxData, listing: dict, narrative: Optional[list[str]] = None
+) -> int:
     """
     Scores multiple areas of the carfax report to return a risk level
 
@@ -237,7 +250,9 @@ def rate_risk_level2(carfax: CarfaxData, listing: dict, narrative: list[str]) ->
     return round(max(min(score, 10.0), 0.0))
 
 
-def score_title_status(carfax: CarfaxData, narrative: list[str]) -> float:
+def score_title_status(
+    carfax: CarfaxData, narrative: Optional[list[str]] = None
+) -> float:
     """
     Computes a composite title risk score on a 0-10 scale based on title type, structural status,
     damage history, and key risk factors (airbags, odometer).
@@ -264,14 +279,15 @@ def score_title_status(carfax: CarfaxData, narrative: list[str]) -> float:
 
     # 4. Airbag deployment: hidden safety concern, flat addition
     if carfax.airbags_deployed:
-        narrative.append("Air bags have been deployed at least once.")
+        if narrative is not None:
+            narrative.append("Air bags have been deployed at least once.")
         score += 2.5
 
     return min(max(score, 0.0), 10.0)
 
 
 def get_cumulative_damage_score(
-    severities: list[DamageSeverity], narrative: list[str]
+    severities: list[DamageSeverity], narrative: Optional[list[str]] = None
 ) -> float:
     """
     Returns a cumulative score for a list of damages. Subsequent damages are multipled by 10%,
@@ -289,6 +305,7 @@ def get_cumulative_damage_score(
         base: float = SEVERITY_SCORES.get(damage, 0.0)
         multiplier = 1 if i == 0 else 1.1 + (0.05 * (i - 1))
         score += base * multiplier
+
     if score:
         severity_groups = [list(s) for _, s in groupby(severities)]
         totals = []
@@ -296,14 +313,17 @@ def get_cumulative_damage_score(
             count = len(group)
             label = SEVERITY_LABELS.get(group[0], "unknown")
             totals.append(f"{count} {label}")
-        narrative.append(
-            f"{len(severities)} damage record{"s" if len(totals) > 1 else "" } found: {', '.join(totals)}."
-        )
+
+        if narrative is not None:
+            narrative.append(
+                f"{len(severities)} damage record{"s" if len(totals) > 1 else "" } found: {', '.join(totals)}."
+            )
+
     return min(score, 10.0)
 
 
 def get_structure_score(
-    status: StructuralStatus, damage_score: float, narrative: list[str]
+    status: StructuralStatus, damage_score: float, narrative: Optional[list[str]] = None
 ) -> float:
     """
     Returns a structure score modified by the likelihood of damage on a non-linear scale.
@@ -326,7 +346,7 @@ def get_structure_score(
         scale = (damage_score / 10) ** 1.2
         score = 0.1 + scale * (2.5 - 0.1)
 
-    if score:
+    if score and narrative is not None:
         if status == StructuralStatus.CONFIRMED:
             narrative.append(
                 "At least one damage report confirmed structural problems."
@@ -341,7 +361,10 @@ def get_structure_score(
 
 
 def get_branded_score(
-    is_branded: bool, is_total_loss: bool, damage_score: float, narrative: list[str]
+    is_branded: bool,
+    is_total_loss: bool,
+    damage_score: float,
+    narrative: Optional[list[str]] = None,
 ) -> float:
     """
     Returns a scaled title score depending on the vehicle's damage.
@@ -369,14 +392,16 @@ def get_branded_score(
         else:
             scale = (damage_score / 10) ** 0.78
             return 2.0 + scale * 5.5  # clean-title curve: 2.25 → 7.5
-    elif is_branded and is_total_loss:
-        narrative.append(
-            "Title has been branded and vehicle was considered a total loss vehicle."
-        )
-    elif is_branded:
-        narrative.append("Title has been branded.")
-    else:
-        narrative.append("Vehicle was declared a total loss.")
+
+    if narrative is not None:
+        if is_branded and is_total_loss:
+            narrative.append(
+                "Title has been branded and vehicle was considered a total loss vehicle."
+            )
+        elif is_branded:
+            narrative.append("Title has been branded.")
+        else:
+            narrative.append("Vehicle was declared a total loss.")
 
     if damage_score <= 0:
         return 7.0  # suspicious: title issue with no visible damage
@@ -386,7 +411,7 @@ def get_branded_score(
 
 
 def score_warranty_status(
-    carfax: CarfaxData, listing: dict, narrative: list[str]
+    carfax: CarfaxData, listing: dict, narrative: Optional[list[str]] = None
 ) -> float:
     """
     Finds the rating score for a vehicle's warranty status. Range is -2 to 0.
@@ -407,11 +432,13 @@ def score_warranty_status(
     coverages: list[dict] = listing["coverages"]
 
     if carfax.has_accident or carfax.has_damage:
-        narrative.append("The basic warranty on this vehicle has been voided.")
+        if narrative is not None:
+            narrative.append("The basic warranty on this vehicle has been voided.")
         return 0.0
 
     if not carfax.is_basic_warranty_active:
-        narrative.append("The basic warranty on this vehicle has expired.")
+        if narrative is not None:
+            narrative.append("The basic warranty on this vehicle has expired.")
         return 0.0
 
     basic_months, basic_miles = carfax.remaining_warranty
@@ -443,7 +470,7 @@ def score_warranty_status(
     else:
         rating = 0.0
 
-    if rating:
+    if rating and narrative is not None:
         narrative.append(
             f"Basic warranty is active with {basic_months} months left and {basic_miles} miles left."
         )
@@ -451,7 +478,9 @@ def score_warranty_status(
     return rating
 
 
-def score_mileage_use(carfax: CarfaxData, listing: dict, narrative: list[str]) -> float:
+def score_mileage_use(
+    carfax: CarfaxData, listing: dict, narrative: Optional[list[str]] = None
+) -> float:
     """
     Calculates a mileage-based risk modifier on a -1.0 to 2.0 scale.
 
@@ -478,7 +507,10 @@ def score_mileage_use(carfax: CarfaxData, listing: dict, narrative: list[str]) -
     """
     # Odometer inconsistency: fraud/mechanical risk
     if carfax.has_odometer_problem:
-        narrative.append("An odometer inconsistency has been found for this vehicle.")
+        if narrative is not None:
+            narrative.append(
+                "An odometer inconsistency has been found for this vehicle."
+            )
         return 2.5
 
     production_year = int(listing["year"])
@@ -497,28 +529,35 @@ def score_mileage_use(carfax: CarfaxData, listing: dict, narrative: list[str]) -
 
     # Continuous scaling: mild penalty below -10%, neutral zone, then 0 → 2 curve above +10%
     if deviation <= -0.20:
-        narrative.append(
-            f"Vehicle has been driven significantly less than expected for it's age ({percent_diff:.1f}%)."
-        )
+        if narrative is not None:
+            narrative.append(
+                f"Vehicle has been driven significantly less than expected for it's age ({percent_diff:.1f}%)."
+            )
         score = -1.0
     elif deviation <= -0.10:
-        narrative.append(
-            f"Vehicle has been driven less than expected for it's age ({percent_diff:.1f}%)."
-        )
+        if narrative is not None:
+            narrative.append(
+                f"Vehicle has been driven less than expected for it's age ({percent_diff:.1f}%)."
+            )
         score = -1.0 + (deviation + 0.20) * 5  # smooth ramp -1 → -0.5
     elif deviation < 0.10:
-        narrative.append(f"Vehicle has been driven an expected amount for it's age.")
+        if narrative is not None:
+            narrative.append(
+                f"Vehicle has been driven an expected amount for it's age."
+            )
         score = 0.0
     elif deviation < 0.40:
-        narrative.append(
-            f"Vehicle has been driven more than expected for it's age ({percent_diff:.1f}%)."
-        )
+        if narrative is not None:
+            narrative.append(
+                f"Vehicle has been driven more than expected for it's age ({percent_diff:.1f}%)."
+            )
         # from +10% → +40%, interpolate 0 → 2.0
         score = ((deviation - 0.10) / 0.30) * 2.0
     else:
-        narrative.append(
-            f"Vehicle has been driven much more than expected for it's age ({percent_diff:.1f}%)."
-        )
+        if narrative is not None:
+            narrative.append(
+                f"Vehicle has been driven much more than expected for it's age ({percent_diff:.1f}%)."
+            )
         score = 2.0
 
     return score

--- a/analysis/workflow.py
+++ b/analysis/workflow.py
@@ -13,7 +13,7 @@ from analysis.normalization import (
 
 from utils.cache import load_cache
 from utils.constants import *
-from utils.models import AnalysisContext
+from utils.models import AnalysisContext, ListingContext, PricingAnchors
 
 
 def build_analysis_context(metadata: dict) -> AnalysisContext:
@@ -28,9 +28,7 @@ def populate_cache(ctx: AnalysisContext):
 
 
 async def populate_variants(ctx: AnalysisContext, listings: list[dict]):
-    # We must normalize listings before getting the variant map
-    norm_listings = [normalize_listing(l) for l in listings]
-    ctx.variant_map = await get_variant_map(ctx.make, ctx.model, norm_listings)
+    ctx.variant_map = await get_variant_map(ctx.make, ctx.model, listings)
 
 
 async def populate_pricing_data(ctx: AnalysisContext, listings: list[dict]):
@@ -39,27 +37,77 @@ async def populate_pricing_data(ctx: AnalysisContext, listings: list[dict]):
     )
 
 
-def populate_filtered_listings(ctx: AnalysisContext, listings: list[dict]):
+def populate_filtered_listings(
+    ctx: AnalysisContext, listings: list[dict], full_listings: list[dict] | None = None
+):
     valid_data, skipped_listings, skip_summary = filter_valid_listings(
         ctx.make, ctx.model, listings, ctx.cache_entries, ctx.variant_map
     )
-    ctx.valid_listings = valid_data
+
     ctx.skipped_listings = skipped_listings
     ctx.skip_summary = skip_summary
 
+    full_listings = full_listings or listings
+
+    ctx.listings = []
+    for vd in valid_data:
+        listing = vd["listing"]
+        cache_key = vd["cache_key"]
+
+        lid = str(listing.get("id", ""))
+        vin = str(listing.get("vin", "") or "")
+
+        # Find the matching “full listing” once, here (so level2 doesn’t do it)
+        full = next((l for l in full_listings if str(l.get("id", "")) == lid), listing)
+
+        report = get_report_dir(full)
+        report_path = str(report) if report else None
+
+        entry = ctx.cache_entries.get(cache_key, {})
+        pricing = PricingAnchors(
+            msrp=entry.get("msrp"),
+            fpp_natl=entry.get("fpp_natl"),
+            fpp_local=entry.get("fpp_local"),
+            fmv=entry.get("fmv"),
+            fmr_low=entry.get("fmr_low"),
+            fmr_high=entry.get("fmr_high"),
+            uncertainty=entry.get("uncertainty"),
+            source_natl=entry.get("natl_source"),
+            source_local=entry.get("local_source"),
+        )
+
+        ctx.listings.append(
+            ListingContext(
+                listing_id=lid,
+                vin=vin,
+                cache_key=cache_key,
+                listing=listing,
+                full_listing=full,
+                report_path=report_path,
+                pricing=pricing,
+            )
+        )
+
 
 async def prepare_level1_analysis(
-    metadata: dict, listings: list[dict], report_listings: list[dict] = []
+    metadata: dict,
+    listings: list[dict],
+    report_listings: list[dict] = [],
+    is_normalized=False,
 ) -> AnalysisContext:
     ctx = build_analysis_context(metadata)
 
-    populate_cache(ctx)
-    await populate_variants(ctx, listings)
-    await populate_pricing_data(ctx, listings)
-    if report_listings:
-        populate_filtered_listings(ctx, report_listings)
+    if is_normalized:
+        norm_listings = listings
     else:
-        populate_filtered_listings(ctx, listings)
+        norm_listings = [normalize_listing(l) for l in listings]
+
+    populate_cache(ctx)
+    await populate_variants(ctx, norm_listings)
+    await populate_pricing_data(ctx, norm_listings)
+    populate_filtered_listings(
+        ctx, report_listings or norm_listings, full_listings=listings
+    )
 
     return ctx
 
@@ -68,20 +116,21 @@ async def prepare_level2_analysis(
     metadata: dict, listings: list[dict], filename: str
 ) -> AnalysisContext:
 
-    # Ensure all folders exist, and if not, save the documents
     if not all(get_vehicle_dir(l) for l in listings):
         await download_files(listings, filename)
 
-    # Filter out only the listings that have a valid report
+    norm_listings = [normalize_listing(l) for l in listings]
+
     filtered_listings = []
-    for vl in listings:
+    for vl in norm_listings:
         report = get_report_dir(vl)
         if report and report.exists():
             filtered_listings.append(vl)
 
-    ctx = await prepare_level1_analysis(metadata, listings)
+    ctx = await prepare_level1_analysis(
+        metadata, norm_listings, filtered_listings, True
+    )
 
-    # Check for missings documents (pdfs, html)
     check_missing_docs(listings)
 
     return ctx

--- a/analysis/workflow.py
+++ b/analysis/workflow.py
@@ -1,0 +1,95 @@
+from analysis.analysis_utils import (
+    check_missing_docs,
+    download_files,
+    get_report_dir,
+    get_vehicle_dir,
+)
+from analysis.kbb import get_pricing_data, get_variant_map
+from analysis.normalization import (
+    filter_valid_listings,
+    get_variant_map,
+    normalize_listing,
+)
+
+from utils.cache import load_cache
+from utils.constants import *
+from utils.models import AnalysisContext
+
+
+def build_analysis_context(metadata: dict) -> AnalysisContext:
+    return AnalysisContext(
+        make=metadata["vehicle"]["make"], model=metadata["vehicle"]["model"]
+    )
+
+
+def populate_cache(ctx: AnalysisContext):
+    ctx.cache = load_cache(PRICING_CACHE)
+    ctx.cache_entries = ctx.cache.setdefault("entries", {})
+
+
+async def populate_variants(ctx: AnalysisContext, listings: list[dict]):
+    # We must normalize listings before getting the variant map
+    norm_listings = [normalize_listing(l) for l in listings]
+    ctx.variant_map = await get_variant_map(ctx.make, ctx.model, norm_listings)
+
+
+async def populate_pricing_data(ctx: AnalysisContext, listings: list[dict]):
+    ctx.trim_valuations = await get_pricing_data(
+        ctx.make, ctx.model, listings, ctx.variant_map, ctx.cache
+    )
+
+
+def populate_filtered_listings(ctx: AnalysisContext, listings: list[dict]):
+    valid_data, skipped_listings, skip_summary = filter_valid_listings(
+        ctx.make, ctx.model, listings, ctx.cache_entries, ctx.variant_map
+    )
+    ctx.valid_listings = valid_data
+    ctx.skipped_listings = skipped_listings
+    ctx.skip_summary = skip_summary
+
+
+async def prepare_level1_analysis(
+    metadata: dict, listings: list[dict], report_listings: list[dict] = []
+) -> AnalysisContext:
+    ctx = build_analysis_context(metadata)
+
+    populate_cache(ctx)
+    await populate_variants(ctx, listings)
+    await populate_pricing_data(ctx, listings)
+    if report_listings:
+        populate_filtered_listings(ctx, report_listings)
+    else:
+        populate_filtered_listings(ctx, listings)
+
+    return ctx
+
+
+async def prepare_level2_analysis(
+    metadata: dict, listings: list[dict], filename: str
+) -> AnalysisContext:
+
+    # Ensure all folders exist, and if not, save the documents
+    if not all(get_vehicle_dir(l) for l in listings):
+        await download_files(listings, filename)
+
+    # Filter out only the listings that have a valid report
+    filtered_listings = []
+    for vl in listings:
+        report = get_report_dir(vl)
+        if report and report.exists():
+            filtered_listings.append(vl)
+
+    ctx = await prepare_level1_analysis(metadata, listings)
+
+    # Check for missings documents (pdfs, html)
+    check_missing_docs(listings)
+
+    return ctx
+
+
+async def prepare_level3_analysis(
+    metadata: dict, listings: list[dict], filename: str
+) -> AnalysisContext:
+    ctx = await prepare_level2_analysis(metadata, listings, filename)
+
+    return ctx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ visor_scraper = "visor_scraper.scraper:main"
 kbb_collect = "analysis.kbb_collector:main"
 level1 = "analysis.level1:main"
 level2 = "analysis.level2:main"
+level3 = "analysis.level3:main"
 download = "utils.download:main"
 
 [tool.setuptools.packages.find]

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from analysis.analysis_utils import get_relevant_entries
 from utils.constants import *
 
 
@@ -53,7 +52,9 @@ def is_local_fresh(entry: dict) -> bool:
 
 
 def cache_covers_all(
-    make: str, variants: list[str], years: list[str], cache: dict
+    variants: list[str],
+    relevant_entries: dict[str, dict[str, dict]],
+    cache: dict,
 ) -> bool:
     cache_entries = cache.get("entries", {})
     slugs = cache.get("model_slugs", {})
@@ -62,19 +63,16 @@ def cache_covers_all(
         return False
 
     for ymm in variants:
-        year: str = ymm[:4]
-        make_model_key: str = ymm[5:].strip()
-        model = make_model_key.replace(make, "")
-
-        # Check model slug
         if ymm not in slugs:
             return False
 
-        relevant_entries = get_relevant_entries(cache_entries, make, model, year)
-        if len(relevant_entries) == 0:
+        year: str = ymm[:4]
+
+        entries_for_year = relevant_entries.setdefault(year, {})
+        if entries_for_year is None:
             return False
 
-        for entry in relevant_entries.values():
+        for entry in entries_for_year.values():
             if is_entry_fresh(entry) is False:
                 return False
 

--- a/utils/constants/analysis.py
+++ b/utils/constants/analysis.py
@@ -263,3 +263,16 @@ FEE_SIGNAL_RE = re.compile(
     r"\b(?:fee|fees|charge|charges|expense)\b",
     re.I,
 )
+
+DOLLAR_AMOUNT_RE = re.compile(
+    r"""
+    ^\$
+    (?:
+        (?:\d{1,3}(?:,\d{3})+)   # 1,234 or 12,345,678
+        |
+        \d+                     # 30012
+    )
+    $
+    """,
+    re.VERBOSE,
+)

--- a/utils/download.py
+++ b/utils/download.py
@@ -483,6 +483,11 @@ def wait_for_carfax_report(ws: WebSocket, sid: str, timeout=90):
         t = (info.get("t") or "").lower()
         href = (info.get("href") or "").lower()
         ready = (info.get("ready") or "").lower()
+
+        host = (urlparse(href).hostname or "").lower()
+        if host == "secure.carfax.com":
+            raise RuntimeError("secure.carfax.com redirect")
+
         if "access blocked" in t or "/record-check" in href:
             raise RuntimeError("access blocked")
         if "vehicle history report" in t and "carfax" in t and ready == "complete":

--- a/utils/models.py
+++ b/utils/models.py
@@ -2,7 +2,7 @@ import re
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from utils.constants import (
     BED_LENGTH_RE,
@@ -46,7 +46,7 @@ class TrimValuation:
             f"trim_source={self.local_source!r})"
         )
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "model": self.model,
             "kbb_trim": self.kbb_trim,
@@ -61,7 +61,7 @@ class TrimValuation:
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "TrimValuation":
+    def from_dict(cls, data: dict[str, Any]) -> "TrimValuation":
         return cls(
             model=data["model"],
             kbb_trim=data["kbb_trim"],
@@ -129,7 +129,7 @@ class CarListing:
             f"deviation_pct={self.deviation_pct!r})"
         )
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "id": self.id,
             "vin": self.vin,
@@ -156,7 +156,7 @@ class CarListing:
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "CarListing":
+    def from_dict(cls, data: dict[str, Any]) -> "CarListing":
         return cls(
             id=data["id"],
             vin=data["vin"],
@@ -189,7 +189,7 @@ class DealBin:
     listings: list[CarListing]
     count: int
     avg_deviation_pct: Optional[float] = None
-    condition_counts: Dict[str, int] = field(default_factory=dict)  # {"New": 2, ...}
+    condition_counts: dict[str, int] = field(default_factory=dict)  # {"New": 2, ...}
     percent_of_total: Optional[float] = None  # 0..100
 
     @property
@@ -242,7 +242,7 @@ class TrimProfile:
     tokens: list[str]
     full_trim: str
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "full_trim": self.full_trim,
             "tokens": self.tokens,
@@ -592,3 +592,19 @@ class DealCheck:
     inventory_trend: dict[str, tuple[int, int]]
     visual_graph_bytes: bytes
     dealcheck_url: str
+
+
+@dataclass
+class AnalysisContext:
+    # Level 1
+    make: str
+    model: str
+    cache: dict[str, Any] = field(default_factory=dict)
+    cache_entries: dict[str, dict[str, Any]] = field(default_factory=dict)
+    variant_map: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    trim_valuations: list[TrimValuation] = field(default_factory=list)
+
+    # Level 2
+    valid_listings: list[dict[str, Any]] = field(default_factory=list)
+    skipped_listings: list[dict[str, Any]] = field(default_factory=list)
+    skip_summary: dict[str, dict[str, int]] = field(default_factory=dict)

--- a/utils/models.py
+++ b/utils/models.py
@@ -595,16 +595,55 @@ class DealCheck:
 
 
 @dataclass
+class PricingAnchors:
+    msrp: Optional[int] = None
+    fpp_natl: Optional[int] = None
+    fpp_local: Optional[int] = None
+    fmv: Optional[int] = None
+    fmr_low: Optional[int] = None
+    fmr_high: Optional[int] = None
+    uncertainty: Optional[str] = None
+    source_natl: Optional[str] = None
+    source_local: Optional[str] = None
+
+
+@dataclass
+class ListingContext:
+    listing_id: str
+    vin: str = ""
+    cache_key: str = ""
+
+    listing: dict[str, Any] = field(default_factory=dict)
+    full_listing: dict[str, Any] = field(default_factory=dict)
+
+    report_path: Optional[str] = None
+    carfax: Any | None = None
+
+    pricing: PricingAnchors = field(default_factory=PricingAnchors)
+
+    # “figure out the leverage” output
+    leverage_lines: list[str] = field(default_factory=list)
+
+    # Level 2 and 3 outputs
+    deal_rating: Optional[str] = None
+    risk_score: Optional[int] = None
+    narrative: list[str] = field(default_factory=list)
+
+
+@dataclass
 class AnalysisContext:
     # Level 1
     make: str
     model: str
+
     cache: dict[str, Any] = field(default_factory=dict)
     cache_entries: dict[str, dict[str, Any]] = field(default_factory=dict)
     variant_map: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
     trim_valuations: list[TrimValuation] = field(default_factory=list)
 
-    # Level 2
-    valid_listings: list[dict[str, Any]] = field(default_factory=list)
     skipped_listings: list[dict[str, Any]] = field(default_factory=list)
     skip_summary: dict[str, dict[str, int]] = field(default_factory=dict)
+
+    listings: list[ListingContext] = field(default_factory=list)
+
+    # Level 2


### PR DESCRIPTION
Major changes:
- Added many models for passing information across for all levels to reduce code duplication 
- Created workflow.py to manage data loading for those models to avoid circular dependencies

Minor changes:
- Initial level3.py commit and shortcut
- Narrative is now optional since level 3 does not require it
- Extracted functions into analysis_utils
- Tweaked error messages to be more specific

Bug fixes
- Check for paywalls through url for time-saving
- Return errors for national data instead of printing directly to console
- Explicitly check for dollar amounts in the national data tables