### PR TITLE
feat(api): translate listing search filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ individual listing detail. Filters use the parameter names from the official Vis
 API; sequences are encoded as comma-separated values.
 
 ```python
-from visor_api import VisorClient
+from visor_api import VisorClient, adapt_search_response
 from visor_scraper.config import get_visor_api_key
 
 
@@ -66,7 +66,20 @@ listing = client.get_listing(
 	listings["data"][0]["id"],
 	{"include": "price_history,options"},
 )
+
+# Convert API records to the existing DealLens metadata/listings contract.
+payload = adapt_search_response(
+	listings,
+	details={listing["data"]["id"]: listing["data"]},
+	request_filters=filters,
+)
 ```
+
+The adapter prefers non-null detail values, retains every untouched API record in
+`source_data`, and records source paths, calculations, and unavailable reasons in
+`provenance`. Facet responses can be supplied through `facets_response`; aggregate
+market values are kept in metadata and a separate `facet_result`, never copied onto
+individual listings.
 
 The client sends the configured key only in the `Authorization: Bearer` header,
 uses a 10-second connection timeout and a 30-second response/read timeout, and

--- a/analysis/normalization.py
+++ b/analysis/normalization.py
@@ -309,25 +309,38 @@ def normalize_listing(listing: dict) -> dict:
     """Convert a raw listing into the minimal Level-1 schema."""
 
     addl = listing.get("additional_docs", {}) or {}
-    carfax_present: bool = bool_from_url(addl.get("carfax_url"))
+    carfax_present: bool | None = bool_from_url(addl.get("carfax_url"))
     # autocheck_present: bool = bool_from_url(addl.get("autocheck_url"))
-    sticker_present: bool = bool_from_url(addl.get("window_sticker_url"))
+    sticker_present: bool | None = bool_from_url(addl.get("window_sticker_url"))
 
     specs: dict = listing.get("specs", {})
-    fuel_type: str = specs.get("Fuel Type", "").strip().lower()
-    listing_url: str = listing.get("listing_url", "").lower()
+    fuel_type: str = str(specs.get("Fuel Type") or "").strip().lower()
+    powertrain_type: str = str(specs.get("Powertrain Type") or "").strip().lower()
+    listing_url: str = str(listing.get("listing_url") or "").lower()
     if not listing_url:
         print(f"Listing URL invalid for {listing.get("id")}")
 
-    is_hybrid = False
-    is_plugin = False
-    if "hybrid" in fuel_type or "hybrid" in listing_url:
+    is_hybrid: bool | None = False
+    is_plugin: bool | None = False
+    if "hybrid" in fuel_type or powertrain_type in {"hev", "phev"} or "hybrid" in listing_url:
         is_hybrid = True
-        if "plug" in fuel_type or "plug" in listing_url:
+        if "plug" in fuel_type or powertrain_type == "phev" or "plug" in listing_url:
             is_plugin = True
-    elif fuel_type == "" or fuel_type == "not specified":
+    elif fuel_type in {"", "not specified"} and not powertrain_type:
         is_hybrid = None  # unknown
         is_plugin = None  # unknown
+
+    source_data = listing.get("source_data", {}) or {}
+    is_api_listing = source_data.get("provider") == "visor_api"
+    detail = source_data.get("detail_listing", {}) or {}
+    build = (detail.get("vehicle", {}) or {}).get("build", {}) or {}
+    if "window_sticker_verified" in build:
+        sticker_present = build["window_sticker_verified"]
+    elif not bool_from_url(addl.get("window_sticker_url")):
+        sticker_present = None
+
+    if is_api_listing and not bool_from_url(addl.get("carfax_url")):
+        carfax_present = None
 
     war = listing.get("warranty", {}) or {}
     # Treat "present" as: either a non-unknown overall_status or any coverages listed
@@ -335,6 +348,8 @@ def normalize_listing(listing: dict) -> dict:
         str(war.get("overall_status", "")).strip().lower()
         not in {"", "unknown", "n/a", "none"}
     )
+    if is_api_listing and listing.get("warranty") is None:
+        warranty_present = None
 
     tv = specs.get("Trim Version", "")
     valid_tv = tv if is_trim_version_valid(tv) else ""
@@ -355,7 +370,7 @@ def normalize_listing(listing: dict) -> dict:
         "window_sticker_present": sticker_present,
         "warranty_info_present": warranty_present,
         # Level 2
-        "coverages": listing.get("warranty", {}).get("coverages", []),
+        "coverages": (listing.get("warranty") or {}).get("coverages", []),
         "seller": listing.get("seller", {}),
         "visor_listing": f"https://visor.vin/search/listings/{listing.get("vin")}",
         "dealer_listing": listing.get("listing_url"),

--- a/tests/unit/test_visor_adapter.py
+++ b/tests/unit/test_visor_adapter.py
@@ -1,0 +1,152 @@
+import json
+
+from pathlib import Path
+
+from analysis.normalization import normalize_listing
+from visor_api import adapt_facets_response, adapt_listing, adapt_search_response
+
+
+FIXTURES = Path(__file__).parents[2] / "docs" / "fixtures" / "visor_api"
+
+
+def fixture(name):
+	with (FIXTURES / name).open(encoding="utf-8") as stream:
+		return json.load(stream)
+
+
+def test_adapter_maps_complete_search_and_detail_contract():
+	search = fixture("listing_search.json")["data"][0]
+	detail = fixture("listing_detail.json")["data"]
+
+	listing = adapt_listing(search, detail)
+
+	assert listing["id"] == "00000000000000000000000000000001"
+	assert listing["vin"] == "1TEST000000000001"
+	assert listing["title"] == "2026 Example Make Example Model Example Trim"
+	assert listing["year"] == 2026
+	assert listing["trim"] == "Example Trim"
+	assert listing["price"] == 34000
+	assert listing["mileage"] == 0
+	assert listing["condition"] == "New"
+	assert listing["listed"] == "2026-01-02"
+	assert listing["listing_url"].startswith("https://dealer.example.invalid/")
+	assert listing["images"] == ["https://images.example.invalid/vehicle-1.jpg"]
+	assert listing["seller"] == {
+		"name": "Example Motors",
+		"location": "Example City, CO 00000",
+		"phone": "(000) 000-0000",
+		"stock_number": None,
+	}
+	assert listing["specs"] == {
+		"Trim Version": "Example Trim Hybrid",
+		"Body Style": "Sedan",
+		"Drivetrain": "FWD",
+		"Fuel Type": "Hybrid",
+		"Powertrain Type": "HEV",
+		"Transmission": "CVT",
+		"Engine": "2.5L I4",
+		"Cylinders": 4,
+		"Doors": 4,
+		"Seating Capacity": 5,
+		"Exterior Color": "Example Blue",
+		"Interior Color": None,
+		"Base Exterior Color": "Blue",
+		"Base Interior Color": None,
+		"Assembly Location": None,
+	}
+	assert listing["installed_addons"] == {
+		"items": [{"name": "Example Package", "price": 500}],
+		"total": 500,
+	}
+	assert listing["price_history"] == []
+	assert listing["additional_docs"] == {
+		"carfax_url": None,
+		"autocheck_url": None,
+		"window_sticker_url": None,
+	}
+	assert listing["source_data"]["detail_listing"]["pricing"] == detail["pricing"]
+	assert listing["source_data"]["search_listing"]["features"] == search["features"]
+	assert listing["provenance"]["title"]["kind"] == "calculated"
+	assert listing["provenance"]["additional_docs.carfax_url"]["reason"] == "not_provided_by_api"
+
+
+def test_detail_values_are_preferred_but_nulls_fall_back_to_search():
+	search = {"id": 123, "price": 20_000, "miles": 12, "year": 2024, "make": "A", "model": "B"}
+	detail = {"id": 123, "price": 19_000, "miles": None, "vehicle": {"build": {"year": 2025}}}
+
+	listing = adapt_listing(search, detail)
+
+	assert listing["id"] == "123"
+	assert listing["price"] == 19_000
+	assert listing["mileage"] == 12
+	assert listing["year"] == 2025
+
+
+def test_unknown_condition_and_unrequested_collections_remain_unavailable():
+	listing = adapt_listing({"id": "one", "inventory_type": "fleet"})
+
+	assert listing["condition"] is None
+	assert listing["installed_addons"] == {"items": None, "total": None}
+	assert listing["price_history"] is None
+	assert listing["provenance"]["condition"]["reason"] == "unknown_inventory_type"
+
+
+def test_price_history_has_explicit_compatibility_shape_without_fabricated_fields():
+	listing = adapt_listing(
+		{"id": "one"},
+		{"price_history": [{"timestamp": "2026-01-01T00:00:00Z", "price": 10_000, "change": -500, "source": "dealer"}]},
+	)
+
+	assert listing["price_history"] == [{"date": "2026-01-01T00:00:00Z", "price": 10_000, "price_change": -500}]
+	assert "lowest" not in listing["price_history"][0]
+	assert "mileage" not in listing["price_history"][0]
+	assert listing["source_data"]["detail_listing"]["price_history"][0]["source"] == "dealer"
+
+
+def test_search_envelope_and_facets_map_to_metadata_without_touching_listings():
+	search_response = fixture("listing_search.json")
+	facets_response = fixture("facets.json")
+
+	result = adapt_search_response(
+		search_response,
+		request_filters={"make": "Example Make"},
+		facets_response=facets_response,
+		captured_at="2026-07-18T12:00:00+00:00",
+	)
+
+	assert set(result) == {"metadata", "listings", "source_data", "facet_result"}
+	assert result["metadata"]["vehicle"] == {
+		"make": "Example Make",
+		"model": "Example Model",
+		"trim": "Example Trim",
+		"year": 2026,
+	}
+	assert result["metadata"]["site_info"]["total_for_sale"] == 100
+	assert result["metadata"]["site_info"]["stats"]["price"]["missing"] == 10
+	assert "stats" not in result["listings"][0]
+	assert result["metadata"]["pagination"] == search_response["pagination"]
+	assert result["facet_result"]["request_filters"] == {"make": "Example Make"}
+	assert result["facet_result"]["captured_at"] == "2026-07-18T12:00:00+00:00"
+
+
+def test_facet_adapter_preserves_null_or_missing_sections():
+	result = adapt_facets_response({"data": {"total": 0}}, captured_at="now")
+
+	assert result["total"] == 0
+	assert result["facets"] is None
+	assert result["range_facets"] is None
+	assert result["stats"] is None
+
+
+def test_api_build_facts_drive_existing_normalized_fields():
+	search = fixture("listing_search.json")["data"][0]
+	detail = fixture("listing_detail.json")["data"]
+
+	normalized = normalize_listing(adapt_listing(search, detail))
+
+	assert normalized["trim_version"] == "Example Trim Hybrid"
+	assert normalized["is_hybrid"] is True
+	assert normalized["is_plugin"] is False
+	assert normalized["window_sticker_present"] is False
+	assert normalized["report_present"] is None
+	assert normalized["warranty_info_present"] is None

--- a/tests/unit/test_visor_client.py
+++ b/tests/unit/test_visor_client.py
@@ -266,3 +266,49 @@ def test_get_listing_rejects_empty_identifier():
 
 	with pytest.raises(ValueError, match="listing_id"):
 		client.get_listing(" ")
+
+
+def test_filter_all_listings_uses_offset_pagination_and_requested_limit():
+	opener = FakeOpener(
+		FakeResponse({
+			"data": [{"id": index} for index in range(100)],
+			"pagination": {
+				"limit": 100,
+				"offset": 0,
+				"next_offset": 100,
+				"total": 125,
+			},
+			"meta": {},
+		}),
+		FakeResponse({
+			"data": [{"id": index} for index in range(100, 125)],
+			"pagination": {
+				"limit": 25,
+				"offset": 100,
+				"next_offset": None,
+				"total": 125,
+			},
+			"meta": {},
+		}),
+	)
+	client = VisorClient("test-api-key", opener=opener)
+
+	response = client.filter_all_listings({"make": "Toyota"}, max_listings=125)
+
+	assert len(response["data"]) == 125
+	assert parse_qs(urlparse(opener.requests[0][1]).query)["limit"] == ["100"]
+	assert parse_qs(urlparse(opener.requests[1][1]).query) == {
+		"make": ["Toyota"], "limit": ["25"], "offset": ["100"]
+	}
+
+
+def test_filter_all_listings_stops_on_short_empty_page():
+	opener = FakeOpener(FakeResponse({
+		"data": [],
+		"pagination": {"limit": 50, "offset": 0, "next_offset": None, "total": 0},
+		"meta": {},
+	}))
+	client = VisorClient("test-api-key", opener=opener)
+
+	assert client.filter_all_listings(max_listings=50)["data"] == []
+	assert len(opener.requests) == 1

--- a/tests/unit/test_visor_query.py
+++ b/tests/unit/test_visor_query.py
@@ -1,0 +1,83 @@
+from visor_api import LISTING_EXPANSIONS, LISTING_FIELDS, VisorListingQuery
+
+
+def test_legacy_url_options_map_to_public_api_parameters():
+	query = VisorListingQuery.from_url(
+		"https://visor.vin/search/listings?make=Toyota&model=Camry"
+		"&trim=XSE,LE&year=2025,2024&car_type=Used,CPO"
+		"&price_min=20000&price_max=40000&miles_min=1000&miles_max=50000"
+		"&location=80202&radius=100&sort=cheapest"
+	)
+
+	assert query.filters == {
+		"make": ("Toyota",),
+		"model": ("Camry",),
+		"trim": ("LE", "XSE"),
+		"year": ("2024", "2025"),
+		"inventory_type": ("certified", "used"),
+		"min_price": "20000",
+		"max_price": "40000",
+		"min_mileage": "1000",
+		"max_mileage": "50000",
+		"postal_code": "80202",
+		"radius": "100",
+		"sort": "price",
+	}
+	assert query.unsupported == {}
+
+
+def test_named_location_and_unknown_browser_options_are_reported():
+	query = VisorListingQuery.from_url(
+		"https://visor.vin/search/listings?location=Denver%2C+CO&agnostic=false"
+	)
+
+	assert query.filters == {}
+	assert query.unsupported == {"location": "Denver, CO", "agnostic": "false"}
+
+
+def test_projection_and_fingerprint_are_normalized():
+	first = VisorListingQuery.from_url(
+		"https://visor.vin/search/listings?trim=XSE,LE&year=2025,2024"
+	)
+	second = VisorListingQuery.from_url(
+		"https://visor.vin/search/listings?year=2024,2025&trim=LE,XSE"
+	)
+
+	assert first.api_params()["fields"] == LISTING_FIELDS
+	assert first.api_params()["include"] == LISTING_EXPANSIONS
+	assert first.fingerprint(50) == second.fingerprint(50)
+
+
+def test_current_browser_geo_parameters_map_to_postal_radius_query():
+	query = VisorListingQuery.from_url(
+		"https://visor.vin/search/listings?make=Subaru&model=Forester"
+		"&year=%222024%22&geo_origin_kind=postal_code"
+		"&geo_origin_value=%2280013%22&geo_mode=radius"
+		"&geo_distance_value=%22100%22&geo_distance_unit=mi"
+	)
+
+	assert query.filters == {
+		"make": ("Subaru",),
+		"model": ("Forester",),
+		"year": ("2024",),
+		"postal_code": "80013",
+		"radius": "100",
+	}
+	assert query.unsupported == {}
+
+
+def test_unsupported_geo_shape_is_reported_instead_of_silently_invented():
+	query = VisorListingQuery.from_url(
+		"https://visor.vin/search/listings?geo_origin_kind=city"
+		"&geo_origin_value=Denver&geo_mode=radius"
+		"&geo_distance_value=100&geo_distance_unit=km"
+	)
+
+	assert query.filters == {}
+	assert query.unsupported == {
+		"geo_origin_kind": "city",
+		"geo_origin_value": "Denver",
+		"geo_mode": "radius",
+		"geo_distance_value": "100",
+		"geo_distance_unit": "km",
+	}

--- a/visor_api/__init__.py
+++ b/visor_api/__init__.py
@@ -7,6 +7,8 @@ from visor_api.client import (
 	VisorReadTimeoutError,
 	VisorTimeoutError,
 )
+from visor_api.adapter import adapt_facets_response, adapt_listing, adapt_search_response
+from visor_api.query import LISTING_EXPANSIONS, LISTING_FIELDS, VisorListingQuery
 
 
 __all__ = [
@@ -15,4 +17,10 @@ __all__ = [
 	"VisorConnectionTimeoutError",
 	"VisorReadTimeoutError",
 	"VisorTimeoutError",
+	"VisorListingQuery",
+	"LISTING_EXPANSIONS",
+	"LISTING_FIELDS",
+	"adapt_facets_response",
+	"adapt_listing",
+	"adapt_search_response",
 ]

--- a/visor_api/adapter.py
+++ b/visor_api/adapter.py
@@ -1,0 +1,301 @@
+"""Adapt Visor Public API payloads to the legacy DealLens listing contract."""
+
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any
+
+
+CONDITION_MAP = {
+	"new": "New",
+	"used": "Used",
+	"certified": "Certified",
+}
+
+SPEC_FIELDS = {
+	"version": "Trim Version",
+	"body_type": "Body Style",
+	"drivetrain": "Drivetrain",
+	"fuel_type": "Fuel Type",
+	"powertrain_type": "Powertrain Type",
+	"transmission": "Transmission",
+	"engine": "Engine",
+	"cylinders": "Cylinders",
+	"doors": "Doors",
+	"seating_capacity": "Seating Capacity",
+	"exterior_color": "Exterior Color",
+	"interior_color": "Interior Color",
+	"base_exterior_color": "Base Exterior Color",
+	"base_interior_color": "Base Interior Color",
+	"assembly_location": "Assembly Location",
+}
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+	return value if isinstance(value, Mapping) else {}
+
+
+def _sequence(value: Any) -> list[Any] | None:
+	if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+		return list(value)
+	return None
+
+
+def _first(*values: Any) -> Any:
+	return next((value for value in values if value is not None), None)
+
+
+def _source_value(
+	search: Mapping[str, Any], detail: Mapping[str, Any], build: Mapping[str, Any], key: str
+) -> tuple[Any, str | None]:
+	if build.get(key) is not None:
+		return build[key], f"vehicle.build.{key}"
+	if detail.get(key) is not None:
+		return detail[key], key
+	if search.get(key) is not None:
+		return search[key], key
+	return None, None
+
+
+def _location(dealer: Mapping[str, Any]) -> str | None:
+	city = dealer.get("city")
+	state = dealer.get("state")
+	postal_code = dealer.get("postal_code")
+	city_state = ", ".join(str(value) for value in (city, state) if value)
+	return " ".join(value for value in (city_state, str(postal_code) if postal_code else "") if value) or None
+
+
+def _adapt_options(value: Any) -> tuple[list[dict[str, Any]] | None, int | None]:
+	options = _sequence(value)
+	if options is None:
+		return None, None
+	items: list[dict[str, Any]] = []
+	prices: list[int | float] = []
+	for raw_option in options:
+		option = _mapping(raw_option)
+		price = option.get("msrp")
+		items.append({"name": option.get("name"), "price": price})
+		if isinstance(price, (int, float)) and not isinstance(price, bool):
+			prices.append(price)
+	return items, sum(prices)
+
+
+def _adapt_price_history(value: Any) -> list[dict[str, Any]] | None:
+	history = _sequence(value)
+	if history is None:
+		return None
+	result = []
+	for raw_entry in history:
+		entry = _mapping(raw_entry)
+		result.append(
+			{
+				"date": _first(
+					entry.get("timestamp"),
+					entry.get("recorded_at"),
+					entry.get("changed_at"),
+					entry.get("date"),
+				),
+				"price": entry.get("price"),
+				"price_change": _first(entry.get("price_change"), entry.get("change")),
+			}
+		)
+	return result
+
+
+def adapt_listing(
+	search_listing: Mapping[str, Any] | None,
+	detail_listing: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+	"""Combine a search row and optional detail object into one legacy listing.
+
+	The original source objects are retained verbatim under ``source_data``. Detail
+	values take precedence when present; missing scalar facts remain ``None``.
+	"""
+	search = _mapping(search_listing)
+	detail = _mapping(detail_listing)
+	vehicle = _mapping(detail.get("vehicle"))
+	build = _mapping(vehicle.get("build"))
+	dealer = _mapping(detail.get("dealer"))
+	if not dealer:
+		dealer = {
+			"dealer_id": search.get("dealer_id"),
+			"name": search.get("dealer_name"),
+			"city": search.get("city"),
+			"state": search.get("state"),
+			"postal_code": search.get("postal_code"),
+			"latitude": search.get("latitude"),
+			"longitude": search.get("longitude"),
+		}
+
+	provenance: dict[str, dict[str, Any]] = {}
+
+	def fact(legacy_path: str, key: str) -> Any:
+		value, source_path = _source_value(search, detail, build, key)
+		provenance[legacy_path] = (
+			{"kind": "source_fact", "api_path": source_path}
+			if source_path
+			else {"kind": "unavailable", "reason": "not_provided_by_api"}
+		)
+		return value
+
+	year = fact("year", "year")
+	make = fact("metadata.vehicle.make", "make")
+	model = fact("metadata.vehicle.model", "model")
+	trim = fact("trim", "trim")
+	title_parts = [str(value) for value in (year, make, model, trim) if value is not None]
+	title = " ".join(title_parts) or None
+	provenance["title"] = {
+		"kind": "calculated",
+		"rule": "join non-null year, make, model, and trim with spaces",
+		"inputs": ["year", "make", "model", "trim"],
+	}
+
+	inventory_type = _first(detail.get("inventory_type"), search.get("inventory_type"))
+	condition = CONDITION_MAP.get(str(inventory_type).lower()) if inventory_type is not None else None
+	provenance["condition"] = (
+		{"kind": "calculated", "api_path": "inventory_type", "rule": "inventory type label mapping"}
+		if condition is not None
+		else {
+			"kind": "unavailable",
+			"reason": "unknown_inventory_type" if inventory_type is not None else "not_provided_by_api",
+			"source_value": inventory_type,
+		}
+	)
+
+	options_source = _first(build.get("options"), detail.get("options"), search.get("options"))
+	option_items, option_total = _adapt_options(options_source)
+	provenance["installed_addons.items"] = {
+		"kind": "source_fact",
+		"api_path": "vehicle.build.options/options",
+	} if option_items is not None else {"kind": "unavailable", "reason": "not_requested_or_not_provided"}
+	provenance["installed_addons.total"] = {
+		"kind": "calculated",
+		"rule": "sum non-null option msrp values",
+		"inputs": ["vehicle.build.options[].msrp", "options[].msrp"],
+	} if option_items is not None else {"kind": "unavailable", "reason": "not_requested_or_not_provided"}
+
+	specs = {label: fact(f'specs["{label}"]', key) for key, label in SPEC_FIELDS.items()}
+	listed = _first(detail.get("inventory_date"), detail.get("listed_at"), search.get("listed_at"))
+	provenance["listed"] = {
+		"kind": "source_fact",
+		"api_path": "inventory_date" if detail.get("inventory_date") is not None else "listed_at",
+	} if listed is not None else {"kind": "unavailable", "reason": "not_provided_by_api"}
+
+	photos = _first(detail.get("photo_urls"), search.get("photo_urls"))
+	images = _sequence(photos)
+	if images is None:
+		images = []
+	provenance["images"] = {"kind": "source_fact", "api_path": "photo_urls"}
+
+	price_history_source = _first(detail.get("price_history"), search.get("price_history"))
+	price_history = _adapt_price_history(price_history_source)
+	provenance["price_history"] = {
+		"kind": "source_fact",
+		"api_path": "price_history",
+	} if price_history is not None else {"kind": "unavailable", "reason": "not_requested_or_not_provided"}
+
+	listing = {
+		"id": str(_first(detail.get("id"), search.get("id"))) if _first(detail.get("id"), search.get("id")) is not None else None,
+		"vin": _first(detail.get("vin"), vehicle.get("vin"), search.get("vin")),
+		"title": title,
+		"year": year,
+		"trim": trim,
+		"condition": condition,
+		"price": _first(detail.get("price"), search.get("price")),
+		"mileage": _first(detail.get("miles"), search.get("miles")),
+		"listed": listed,
+		"listing_url": _first(detail.get("vdp_url"), search.get("vdp_url")),
+		"images": images,
+		"seller": {
+			"name": dealer.get("name"),
+			"location": _location(dealer),
+			"phone": dealer.get("phone"),
+			"stock_number": _first(detail.get("stock_number"), search.get("stock_number")),
+		},
+		"specs": specs,
+		"installed_addons": {"items": option_items, "total": option_total},
+		"price_history": price_history,
+		"additional_docs": {
+			"carfax_url": None,
+			"autocheck_url": None,
+			"window_sticker_url": None,
+		},
+		"warranty": None,
+		"market_velocity": None,
+		"source_data": {
+			"provider": "visor_api",
+			"search_listing": deepcopy(search_listing),
+			"detail_listing": deepcopy(detail_listing),
+		},
+		"provenance": provenance,
+	}
+	for legacy_path, api_key in (
+		("id", "id"), ("vin", "vin"), ("price", "price"), ("mileage", "miles"),
+		("listing_url", "vdp_url"), ("seller.name", "name"),
+		("seller.phone", "phone"), ("seller.stock_number", "stock_number"),
+	):
+		if legacy_path not in provenance:
+			provenance[legacy_path] = {"kind": "source_fact", "api_path": api_key}
+
+	for path in ("additional_docs.carfax_url", "additional_docs.autocheck_url", "additional_docs.window_sticker_url", "warranty", "market_velocity"):
+		provenance[path] = {"kind": "unavailable", "reason": "not_provided_by_api"}
+	return listing
+
+
+def adapt_facets_response(
+	response: Mapping[str, Any],
+	*,
+	request_filters: Mapping[str, Any] | None = None,
+	captured_at: str | None = None,
+) -> dict[str, Any]:
+	"""Preserve a facet result separately from individual listing records."""
+	data = _mapping(response.get("data"))
+	return {
+		"total": data.get("total"),
+		"facets": deepcopy(data.get("facets")),
+		"range_facets": deepcopy(data.get("range_facets")),
+		"stats": deepcopy(data.get("stats")),
+		"request_filters": deepcopy(dict(request_filters or {})),
+		"captured_at": captured_at or datetime.now(timezone.utc).isoformat(),
+		"source_data": deepcopy(response),
+	}
+
+
+def adapt_search_response(
+	response: Mapping[str, Any],
+	*,
+	details: Mapping[str, Mapping[str, Any]] | None = None,
+	request_filters: Mapping[str, Any] | None = None,
+	facets_response: Mapping[str, Any] | None = None,
+	captured_at: str | None = None,
+) -> dict[str, Any]:
+	"""Adapt a listing-search response to DealLens's metadata/listings envelope."""
+	rows = _sequence(response.get("data")) or []
+	detail_by_id = details or {}
+	listings = [adapt_listing(_mapping(row), detail_by_id.get(str(_mapping(row).get("id")))) for row in rows]
+	first = listings[0] if listings else {}
+	first_source = _mapping(_mapping(first.get("source_data")).get("search_listing"))
+	metadata = {
+		"vehicle": {
+			"make": first_source.get("make"),
+			"model": first_source.get("model"),
+			"trim": first_source.get("trim"),
+			"year": first_source.get("year"),
+		},
+		"filters": deepcopy(dict(request_filters or {})),
+		"site_info": {},
+		"runtime": {"timestamp": captured_at or datetime.now(timezone.utc).isoformat(), "source": "visor_api"},
+		"warnings": [],
+		"pagination": deepcopy(response.get("pagination")),
+	}
+	result = {"metadata": metadata, "listings": listings, "source_data": {"listing_search": deepcopy(response)}}
+	if facets_response is not None:
+		facet_result = adapt_facets_response(facets_response, request_filters=request_filters, captured_at=captured_at)
+		result["facet_result"] = facet_result
+		metadata["site_info"] = {
+			"total_for_sale": facet_result["total"],
+			"facets": facet_result["facets"],
+			"range_facets": facet_result["range_facets"],
+			"stats": facet_result["stats"],
+		}
+	return result

--- a/visor_api/client.py
+++ b/visor_api/client.py
@@ -119,6 +119,71 @@ class VisorClient:
 		"""Return listing summaries matching the supplied inventory filters."""
 		return self._get("/v1/listings", params)
 
+	def filter_all_listings(
+		self,
+		params: QueryParams | None = None,
+		*,
+		max_listings: int = 50,
+	) -> dict[str, Any]:
+		"""Retrieve offset pages until the requested listing limit is satisfied."""
+		if max_listings < 0:
+			raise ValueError("max_listings must not be negative")
+		base_params = dict(params or {})
+		base_params.pop("limit", None)
+		base_params.pop("offset", None)
+		listings: list[Any] = []
+		last_response: dict[str, Any] = {"data": [], "pagination": {}, "meta": {}}
+		offset = 0
+
+		while len(listings) < max_listings:
+			page_size = min(100, max_listings - len(listings))
+			last_response = self.filter_listings({
+				**base_params,
+				"limit": page_size,
+				"offset": offset,
+			})
+			page = last_response.get("data")
+			if not isinstance(page, list):
+				raise VisorAPIError(
+					200,
+					"expected data to be a list",
+					body=last_response,
+				)
+			listings.extend(page)
+			pagination = last_response.get("pagination")
+			next_offset = (
+				pagination.get("next_offset")
+				if isinstance(pagination, dict)
+				else None
+			)
+			if not page or next_offset is None:
+				break
+			try:
+				next_offset = int(next_offset)
+			except (TypeError, ValueError) as error:
+				raise VisorAPIError(
+					200,
+					"invalid next_offset in pagination",
+					body=last_response,
+				) from error
+			if next_offset <= offset:
+				break
+			offset = next_offset
+
+		return {
+			**last_response,
+			"data": listings[:max_listings],
+			"pagination": {
+				**(
+					last_response.get("pagination")
+					if isinstance(last_response.get("pagination"), dict)
+					else {}
+				),
+				"limit": max_listings,
+				"offset": 0,
+			},
+		}
+
 	def filter_facets(self, params: QueryParams | None = None) -> dict[str, Any]:
 		"""Return facet counts, ranges, and statistics for inventory filters."""
 		return self._get("/v1/facets", params)

--- a/visor_api/query.py
+++ b/visor_api/query.py
@@ -1,0 +1,169 @@
+"""Translate DealLens search options into the public Visor API contract."""
+
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import parse_qsl, urlparse
+
+
+LISTING_FIELDS = (
+	"default,msrp,discount_from_msrp,days_on_market,photo_urls,features,"
+	"options_packages"
+)
+LISTING_EXPANSIONS = "price_history,options"
+
+LEGACY_PARAMETER_NAMES = {
+	"car_type": "inventory_type",
+	"condition": "inventory_type",
+	"price_min": "min_price",
+	"price_max": "max_price",
+	"miles_min": "min_mileage",
+	"miles_max": "max_mileage",
+	"zip": "postal_code",
+}
+
+GEO_BROWSER_PARAMETERS = frozenset({
+	"geo_origin_kind",
+	"geo_origin_value",
+	"geo_mode",
+	"geo_distance_value",
+	"geo_distance_unit",
+})
+
+SORT_VALUES = {
+	"cheapest": "price",
+	"expensive": "-price",
+	"newest": "days_on_market",
+	"oldest": "-days_on_market",
+	"lowest_miles": "miles",
+	"highest_miles": "-miles",
+	"lowest price": "price",
+	"highest price": "-price",
+	"newest": "days_on_market",
+	"oldest": "-days_on_market",
+	"lowest mileage": "miles",
+	"highest mileage": "-miles",
+}
+
+SUPPORTED_PARAMETERS = frozenset({
+	"make", "model", "trim", "year", "inventory_type", "min_price",
+	"max_price", "min_mileage", "max_mileage", "postal_code", "radius",
+	"state", "latitude", "longitude", "sort",
+})
+MULTI_VALUE_PARAMETERS = frozenset({
+	"make", "model", "trim", "year", "inventory_type", "state",
+})
+
+
+def _clean_value(raw_value: Any) -> str:
+	value = str(raw_value).strip()
+	if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+		value = value[1:-1].strip()
+	return value
+
+
+def _values(raw_value: Any) -> tuple[str, ...]:
+	if isinstance(raw_value, (list, tuple, set)):
+		parts = raw_value
+	else:
+		parts = str(raw_value).split(",")
+	return tuple(_clean_value(value) for value in parts if _clean_value(value))
+
+
+def _normalize_condition(value: str) -> str:
+	condition = value.strip().lower()
+	return "certified" if condition in {"certified", "cpo"} else condition
+
+
+@dataclass(frozen=True)
+class VisorListingQuery:
+	"""Normalized API query plus legacy options that could not be translated."""
+
+	filters: dict[str, str | tuple[str, ...]] = field(default_factory=dict)
+	unsupported: dict[str, str] = field(default_factory=dict)
+
+	@classmethod
+	def from_url(cls, url: str) -> "VisorListingQuery":
+		"""Build a query from a legacy Visor browser filter/listing URL."""
+		return cls.from_options(dict(parse_qsl(urlparse(url).query)))
+
+	@classmethod
+	def from_options(cls, options: dict[str, Any]) -> "VisorListingQuery":
+		"""Map DealLens/browser option names to stable public API parameters."""
+		filters: dict[str, str | tuple[str, ...]] = {}
+		unsupported: dict[str, str] = {}
+		geo_options = {
+			name: _clean_value(value)
+			for name, value in options.items()
+			if name in GEO_BROWSER_PARAMETERS and value not in (None, "")
+		}
+
+		for legacy_name, raw_value in options.items():
+			if raw_value is None or raw_value == "":
+				continue
+			if legacy_name in GEO_BROWSER_PARAMETERS:
+				continue
+			name = LEGACY_PARAMETER_NAMES.get(legacy_name, legacy_name)
+			if name == "location":
+				location = _clean_value(raw_value)
+				if len(location) == 5 and location.isdigit():
+					filters["postal_code"] = location
+				else:
+					unsupported[legacy_name] = location
+				continue
+			if name not in SUPPORTED_PARAMETERS:
+				unsupported[legacy_name] = _clean_value(raw_value)
+				continue
+			if name == "sort":
+				value = _clean_value(raw_value)
+				filters[name] = SORT_VALUES.get(value.lower(), value)
+				continue
+			if name in MULTI_VALUE_PARAMETERS:
+				values = _values(raw_value)
+				if name == "inventory_type":
+					values = tuple(_normalize_condition(value) for value in values)
+				filters[name] = tuple(sorted(set(values), key=str.casefold))
+				continue
+			filters[name] = _clean_value(raw_value)
+
+		origin_kind = geo_options.get("geo_origin_kind")
+		origin_value = geo_options.get("geo_origin_value")
+		if origin_kind or origin_value:
+			if origin_kind == "postal_code" and origin_value:
+				filters["postal_code"] = origin_value
+			else:
+				for name in ("geo_origin_kind", "geo_origin_value"):
+					if name in geo_options:
+						unsupported[name] = geo_options[name]
+
+		geo_mode = geo_options.get("geo_mode")
+		distance = geo_options.get("geo_distance_value")
+		unit = geo_options.get("geo_distance_unit")
+		if geo_mode or distance or unit:
+			if geo_mode == "radius" and distance and unit in (None, "mi"):
+				filters["radius"] = distance
+			else:
+				for name in (
+					"geo_mode",
+					"geo_distance_value",
+					"geo_distance_unit",
+				):
+					if name in geo_options:
+						unsupported[name] = geo_options[name]
+
+		return cls(filters=filters, unsupported=unsupported)
+
+	def api_params(self, *, include_projection: bool = True) -> dict[str, str | tuple[str, ...]]:
+		"""Return request parameters, optionally including DealLens' projection."""
+		params = dict(self.filters)
+		if include_projection:
+			params["fields"] = LISTING_FIELDS
+			params["include"] = LISTING_EXPANSIONS
+		return params
+
+	def fingerprint(self, max_listings: int) -> str:
+		"""Return a deterministic cache fingerprint for equivalent API queries."""
+		parts = []
+		for name, value in sorted(self.api_params().items()):
+			encoded = ",".join(value) if isinstance(value, tuple) else value
+			parts.append(f"{name}={encoded}")
+		return "&".join(parts) + f"|max={int(max_listings)}"

--- a/visor_scraper/helpers.py
+++ b/visor_scraper/helpers.py
@@ -4,11 +4,12 @@ import logging
 from argparse import Namespace
 from datetime import date
 from playwright.async_api import ElementHandle, Page
-from urllib.parse import parse_qsl, urlencode, urlparse
+from urllib.parse import parse_qsl, urlparse
 
 from utils.cache import load_cache, save_cache
 from utils.common import current_timestamp
 from utils.constants import *
+from visor_api.query import VisorListingQuery
 
 
 def metadata_years(years: list[str]) -> str:
@@ -48,9 +49,7 @@ def get_today_key() -> str:
 
 
 def get_fingerprint(args: Namespace) -> str:
-    params = parse_qsl(urlparse(args.url).query, keep_blank_values=True)
-    query = urlencode(sorted(params))
-    return f"{query}|max={int(args.max_listings)}"
+    return VisorListingQuery.from_url(args.url).fingerprint(args.max_listings)
 
 
 def get_cache_key(args: Namespace) -> str:

--- a/visor_scraper/scraper.py
+++ b/visor_scraper/scraper.py
@@ -10,7 +10,6 @@ from playwright.async_api import (
     TimeoutError,
 )
 from tqdm import tqdm
-from urllib.parse import parse_qs, urlparse
 
 from analysis.level1 import start_level1_analysis
 from analysis.level2 import start_level2_analysis
@@ -19,6 +18,7 @@ from utils.common import current_timestamp
 from utils.constants import *
 from utils.download import download_files
 from visor_scraper.helpers import *
+from visor_api.query import VisorListingQuery
 
 logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
 
@@ -798,12 +798,12 @@ def apply_url_to_args(args: Namespace) -> Namespace:
     if not args.url:
         logging.error("You must provide a URL")
         exit(1)
-    qs = parse_qs(urlparse(args.url).query)
+    filters = VisorListingQuery.from_url(args.url).filters
 
-    args.make = qs.get("make", [""])[0].strip()
-    args.model = qs.get("model", [""])[0].strip()
-    args.trim = qs.get("trim", [""])[0].split(",") if "trim" in qs else []
-    args.year = qs.get("year", [""])[0].split(",") if "year" in qs else []
+    args.make = next(iter(filters.get("make", ())), "")
+    args.model = next(iter(filters.get("model", ())), "")
+    args.trim = list(filters.get("trim", ()))
+    args.year = list(filters.get("year", ()))
 
     return args
 


### PR DESCRIPTION
Map browser search options to normalized API parameters. Support geo filters, pagination, field projection, and cache fingerprints while preserving quoted values and listing limits.