### PR TITLE
238 migrate level 2 listing evaluation to normalized visor api data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ tests/visor_authenticated/*
 !tests/visor_authenticated/sold_inventory_experiments/*.py
 !tests/visor_authenticated/sold_inventory_experiments/*.md
 issue-226-level-1-task-breakdown.txt
+issue-226-level-2-task-breakdown.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,9 @@ Unless the repository configuration says otherwise:
 - Use the existing `pytest` setup.
 - The project uses `pytest-asyncio` with automatic asyncio handling; do not add `@pytest.mark.asyncio` unless repository configuration requires it.
 - Always check the IDE Problems view for diagnostics in changed files before reporting completion. This includes Pylance in `standard` mode and the VS Code HTML/CSS language-service diagnostics used for HTML, CSS, and Jinja templates. Resolve every reported error and report the result.
+- Treat the VS Code built-in HTML and CSS language services as required validation for templates, including CSS diagnostics reported inside HTML `style` attributes. Do not rely only on successful Jinja rendering, browser output, or pytest when the Problems view reports template errors.
+- Avoid placing Jinja expressions directly inside CSS property values because the CSS language service parses them as invalid CSS. Prefer static classes, `data-*` attributes, or values prepared outside the CSS syntax, while preserving correct rendered output.
+- If the IDE Problems view is unavailable to the agent, do not describe it as checked or clean. Run every available template validation, state that IDE diagnostics remain unverified, and ask for the Problems view to be confirmed before considering template work complete.
 - Add or update tests for changed behavior.
 - Mock external services in unit tests.
 - Use saved fixtures for API and legacy scraper payloads.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,9 @@ If the repository defines a different command, use that instead.
 - Keep changes scoped to the requested task.
 - Do not modify generated output files unless the task specifically concerns them.
 - When asked to make git commit messages, always follow Angular conventions and the 50/72 rule. Do not automatically commit when asked for the message only.
+- After every task that changes code, provide a suggested git commit message for
+  the entire uncommitted worktree. Follow Angular conventions and the 50/72 rule,
+  and do not commit unless explicitly asked.
 
 ## Completion Checklist
 
@@ -144,6 +147,8 @@ Before reporting completion:
 - Note any compatibility impact on legacy scraper data.
 - Update documentation when setup, configuration, or behavior changed.
 - Summarize changed files, important decisions, and remaining risks.
+- For code changes, include the suggested commit message covering all uncommitted
+  worktree changes.
 
 ## Important Links
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,31 @@ The saved DealLens metadata also records the logical `/v1/listings` query and ev
 overall or per-trim `/v1/facets` query with the UTC time its response was retrieved.
 Cache hits retain the original retrieval times.
 
+### Interpreting Level 2 risk and Deal Score
+
+Risk Score measures identified adverse evidence on a 0–10 scale. It includes title,
+damage, structural, odometer, and above-expected-mileage evidence. It is not a
+probability of failure or a universal statement that a vehicle is acceptable. A
+buyer may reasonably treat evidence such as a salvage or rebuilt title as a hard
+stop regardless of the numeric result.
+
+Deal Score measures value after risk rather than vehicle desirability by itself. It
+starts with the listing's linear position on the full price scale, applies an
+exponential risk penalty, and then applies any eligible low-mileage or remaining-
+warranty bonus. Favorable evidence declines as risk rises and contributes nothing at
+risk 4 or above. Consequently, a deeply discounted vehicle with moderate risk can
+receive a higher Deal Score than an exceptionally clean but badly overpriced
+vehicle. The report preserves both Deal Score and Risk Score so buyers can reject a
+vehicle whose risk exceeds their personal tolerance even when its price-adjusted
+value is competitive.
+
+Risk is deliberately nonlinear: movement near the high end costs increasingly more
+Deal Score than the same movement near zero. Roughly, 0–2 represents limited
+identified risk, 3 is a noticeable concern, 4 is a serious-review threshold, 5–6
+receives a major penalty, and 7–10 represents severe evidence that becomes
+increasingly difficult for price to overcome. These descriptions are interpretation
+guidance, not guarantees about condition or future reliability.
+
 The client sends the configured key only in the `Authorization: Bearer` header,
 uses a 10-second connection timeout and a 30-second response/read timeout, and
 retries rate-limit and temporary platform responses a bounded number of times.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ Facet-native Level 1 reports treat user-provided trims as market restrictions.
 Every active and recently sold query applies the selected trims, so the report
 contains only those trim buckets. Omit the trim filter to discover and compare all
 trims returned for the model market.
+
+Level 2 uses an enriched `/v1/listings` search followed by standard listing-detail
+requests. The resulting API records are adapted into the legacy analysis-facing
+listing shape, cached locally, saved under `output/raw`, and passed to the existing
+KBB, dealer-document, CARFAX, scoring, and PDF workflow. New, used, and certified
+inventory are included unless the search URL specifies conditions. Use `--force` to
+bypass the Level 2 API cache.
 The saved DealLens metadata also records the logical `/v1/listings` query and every
 overall or per-trim `/v1/facets` query with the UTC time its response was retrieved.
 Cache hits retain the original retrieval times.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ listing shape, cached locally, saved under `output/raw`, and passed to the exist
 KBB, dealer-document, CARFAX, scoring, and PDF workflow. New, used, and certified
 inventory are included unless the search URL specifies conditions. Use `--force` to
 bypass the Level 2 API cache.
+
+The Level 2 report accounts for every returned listing. A complete rating still
+requires compatible KBB pricing and a saved vehicle-history report. Listings without
+a report are shown separately with a price assessment and an unavailable risk/final
+rating; listings without usable pricing show their evaluation failure reason.
 The saved DealLens metadata also records the logical `/v1/listings` query and every
 overall or per-trim `/v1/facets` query with the UTC time its response was retrieved.
 Cache hits retain the original retrieval times.

--- a/analysis/analysis_utils.py
+++ b/analysis/analysis_utils.py
@@ -150,8 +150,8 @@ def check_missing_docs(listings: list[dict]):
         html = dir / "carfax.html"
         pdf = dir / "carfax.pdf"
 
-        carfax_url = l.get("additional_docs", {}).get("carfax_url", "Unavailable")
-        if carfax_url != "Unavailable" and not pdf.exists() and not html.exists():
+        carfax_url = l.get("additional_docs", {}).get("carfax_url")
+        if bool_from_url(carfax_url) and not pdf.exists() and not html.exists():
             missing_reports.append(l)
 
     if missing_reports:

--- a/analysis/level2.py
+++ b/analysis/level2.py
@@ -8,7 +8,9 @@ from analysis.scoring import (
     adjust_deal_for_evidence,
     calculate_risk_level2,
     classify_deal_rating,
+    deal_strength_within_bin,
     determine_best_price,
+    evidence_adjusted_price,
 )
 from analysis.workflow import prepare_level2_analysis
 
@@ -86,6 +88,8 @@ def _price_assessment(
         "good_end_pct": good_end_pct,
         "fair_end_pct": fair_end_pct,
         "poor_end_pct": poor_end_pct,
+        "scale_low": scale_low,
+        "scale_high": scale_high,
     }
     return deal, midpoint, increment, percent, pricing_visual
 
@@ -156,6 +160,27 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
                 int(pricing_visual["poor_high"]),
             ),
             narrative,
+        )
+        cutoffs = (
+            int(pricing_visual["great_high"]),
+            int(pricing_visual["good_high"]),
+            int(pricing_visual["fair_high"]),
+            int(pricing_visual["poor_high"]),
+        )
+        adjusted_position = evidence_adjusted_price(
+            int(listing["price"]), raw_risk, int(assessment[2])
+        )
+        pricing_visual["deal_strength"] = deal_strength_within_bin(
+            deal, adjusted_position, cutoffs
+        )
+        scale_low = int(pricing_visual["scale_low"])
+        scale_high = int(pricing_visual["scale_high"])
+        pricing_visual["marker_pct"] = max(
+            0.0,
+            min(
+                100.0,
+                (adjusted_position - scale_low) / max(scale_high - scale_low, 1) * 100,
+            ),
         )
         lc.deal_rating = deal
         lc.narrative = narrative

--- a/analysis/level2.py
+++ b/analysis/level2.py
@@ -12,6 +12,7 @@ from analysis.scoring import (
     deal_score_from_position,
     determine_best_price,
     favorable_evidence_bonus,
+    format_deal_score_narrative,
 )
 from analysis.workflow import prepare_level2_analysis
 
@@ -163,9 +164,12 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
             price_deal = deal
             deal = deal_rating_from_score(float(pricing_visual["deal_score"]))
             narrative.append(
-                f"Deal Score is {pricing_visual['deal_score']:.0f}%: price starts at {price_score:.0f}%, "
-                f"risk is {raw_risk:.1f}/10, and favorable evidence contributes "
-                f"{favorable_evidence_bonus(favorable_evidence, raw_risk):.0f} points."
+                format_deal_score_narrative(
+                    float(pricing_visual["deal_score"]),
+                    price_score,
+                    raw_risk,
+                    favorable_evidence_bonus(favorable_evidence, raw_risk),
+                )
             )
             if deal != price_deal:
                 narrative.append(

--- a/analysis/level2.py
+++ b/analysis/level2.py
@@ -8,7 +8,7 @@ from analysis.scoring import (
     adjust_deal_for_evidence,
     calculate_risk_level2,
     classify_deal_rating,
-    deal_strength_within_bin,
+    deal_score_from_position,
     determine_best_price,
     evidence_adjusted_price,
 )
@@ -170,9 +170,6 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
         adjusted_position = evidence_adjusted_price(
             int(listing["price"]), raw_risk, int(assessment[2])
         )
-        pricing_visual["deal_strength"] = deal_strength_within_bin(
-            deal, adjusted_position, cutoffs
-        )
         scale_low = int(pricing_visual["scale_low"])
         scale_high = int(pricing_visual["scale_high"])
         pricing_visual["marker_pct"] = max(
@@ -181,6 +178,9 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
                 100.0,
                 (adjusted_position - scale_low) / max(scale_high - scale_low, 1) * 100,
             ),
+        )
+        pricing_visual["deal_score"] = deal_score_from_position(
+            float(pricing_visual["marker_pct"]), deal
         )
         lc.deal_rating = deal
         lc.narrative = narrative

--- a/analysis/level2.py
+++ b/analysis/level2.py
@@ -5,13 +5,11 @@ from pathlib import Path
 from analysis.analysis_utils import get_report_dir
 from analysis.reporting import render_level2_pdf
 from analysis.scoring import (
-    calculate_deal_score,
+    calculate_deal_score_result,
     calculate_level2_evidence,
     classify_deal_rating,
-    deal_rating_from_score,
     deal_score_from_position,
     determine_best_price,
-    favorable_evidence_bonus,
     format_deal_score_narrative,
 )
 from analysis.workflow import prepare_level2_analysis
@@ -157,19 +155,13 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
         risk = round(raw_risk)
         lc.risk_score = risk
         price_score = deal_score_from_position(float(pricing_visual["marker_pct"]))
-        pricing_visual["deal_score"] = int(
-            calculate_deal_score(price_score, raw_risk, favorable_evidence)
+        score_result = calculate_deal_score_result(
+            price_score, raw_risk, favorable_evidence
         )
+        pricing_visual["deal_score"] = score_result.final_score
         price_deal = deal
-        deal = deal_rating_from_score(float(pricing_visual["deal_score"]))
-        narrative.append(
-            format_deal_score_narrative(
-                float(pricing_visual["deal_score"]),
-                price_score,
-                raw_risk,
-                favorable_evidence_bonus(favorable_evidence, raw_risk),
-            )
-        )
+        deal = score_result.rating
+        narrative.append(format_deal_score_narrative(score_result))
         if deal != price_deal:
             narrative.append(
                 f"The combined score changes the price-only rating from {price_deal} to {deal}."

--- a/analysis/level2.py
+++ b/analysis/level2.py
@@ -44,6 +44,14 @@ def _price_assessment(
     deal, midpoint, increment, percent = classify_deal_rating(
         price, best_comparison, fmv, fpp_local, fmr_high
     )
+    price_difference_pct = (price - midpoint) / midpoint * 100
+    if abs(price_difference_pct) < 0.05:
+        narrative.append("Listing price matches the fair-price midpoint.")
+    else:
+        direction = "above" if price_difference_pct > 0 else "below"
+        narrative.append(
+            f"Listing price is {abs(price_difference_pct):.1f}% {direction} the fair-price midpoint."
+        )
     if deal == "Great" and midpoint and price < midpoint - increment * 3:
         deal = "Suspicious"
 

--- a/analysis/level2.py
+++ b/analysis/level2.py
@@ -52,9 +52,6 @@ def _price_assessment(
         narrative.append(
             f"Listing price is {abs(price_difference_pct):.1f}% {direction} the fair-price midpoint."
         )
-    if deal == "Great" and midpoint and price < midpoint - increment * 3:
-        deal = "Suspicious"
-
     boundaries = [
         midpoint - increment * 3,
         midpoint - increment,
@@ -159,30 +156,24 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
         )
         risk = round(raw_risk)
         lc.risk_score = risk
-        price_score = deal_score_from_position(
-            float(pricing_visual["marker_pct"]), deal
+        price_score = deal_score_from_position(float(pricing_visual["marker_pct"]))
+        pricing_visual["deal_score"] = int(
+            calculate_deal_score(price_score, raw_risk, favorable_evidence)
         )
-        if price_score is None:
-            pricing_visual["deal_score"] = None
-            narrative.append("Deal remains Suspicious because its price is outside the reliable comparison range.")
-        else:
-            pricing_visual["deal_score"] = int(
-                calculate_deal_score(price_score, raw_risk, favorable_evidence)
+        price_deal = deal
+        deal = deal_rating_from_score(float(pricing_visual["deal_score"]))
+        narrative.append(
+            format_deal_score_narrative(
+                float(pricing_visual["deal_score"]),
+                price_score,
+                raw_risk,
+                favorable_evidence_bonus(favorable_evidence, raw_risk),
             )
-            price_deal = deal
-            deal = deal_rating_from_score(float(pricing_visual["deal_score"]))
+        )
+        if deal != price_deal:
             narrative.append(
-                format_deal_score_narrative(
-                    float(pricing_visual["deal_score"]),
-                    price_score,
-                    raw_risk,
-                    favorable_evidence_bonus(favorable_evidence, raw_risk),
-                )
+                f"The combined score changes the price-only rating from {price_deal} to {deal}."
             )
-            if deal != price_deal:
-                narrative.append(
-                    f"The combined score changes the price-only rating from {price_deal} to {deal}."
-                )
         lc.deal_rating = deal
         lc.narrative = narrative
 

--- a/analysis/level2.py
+++ b/analysis/level2.py
@@ -5,11 +5,10 @@ from pathlib import Path
 from analysis.analysis_utils import get_report_dir
 from analysis.reporting import render_level2_pdf
 from analysis.scoring import (
-    adjust_deal_for_risk,
+    adjust_deal_for_evidence,
     calculate_risk_level2,
     classify_deal_rating,
     determine_best_price,
-    supports_deal_upgrade,
 )
 from analysis.workflow import prepare_level2_analysis
 
@@ -145,11 +144,18 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
         risk = round(max(min(raw_risk, 10.0), 0.0))
         lc.risk_score = risk
 
-        deal = adjust_deal_for_risk(
+        deal = adjust_deal_for_evidence(
             deal,
-            risk,
+            raw_risk,
+            int(listing["price"]),
+            int(assessment[2]),
+            (
+                int(pricing_visual["great_high"]),
+                int(pricing_visual["good_high"]),
+                int(pricing_visual["fair_high"]),
+                int(pricing_visual["poor_high"]),
+            ),
             narrative,
-            favorable_evidence=supports_deal_upgrade(raw_risk),
         )
         lc.deal_rating = deal
         lc.narrative = narrative

--- a/analysis/level2.py
+++ b/analysis/level2.py
@@ -5,12 +5,13 @@ from pathlib import Path
 from analysis.analysis_utils import get_report_dir
 from analysis.reporting import render_level2_pdf
 from analysis.scoring import (
-    adjust_deal_for_evidence,
-    calculate_risk_level2,
+    calculate_deal_score,
+    calculate_level2_evidence,
     classify_deal_rating,
+    deal_rating_from_score,
     deal_score_from_position,
     determine_best_price,
-    evidence_adjusted_price,
+    favorable_evidence_bonus,
 )
 from analysis.workflow import prepare_level2_analysis
 
@@ -144,44 +145,32 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
         carfax: CarfaxData = get_carfax_data(report)
         lc.carfax = carfax
 
-        raw_risk = calculate_risk_level2(carfax, listing, narrative)
-        risk = round(max(min(raw_risk, 10.0), 0.0))
+        raw_risk, favorable_evidence = calculate_level2_evidence(
+            carfax, listing, narrative
+        )
+        risk = round(raw_risk)
         lc.risk_score = risk
-
-        deal = adjust_deal_for_evidence(
-            deal,
-            raw_risk,
-            int(listing["price"]),
-            int(assessment[2]),
-            (
-                int(pricing_visual["great_high"]),
-                int(pricing_visual["good_high"]),
-                int(pricing_visual["fair_high"]),
-                int(pricing_visual["poor_high"]),
-            ),
-            narrative,
-        )
-        cutoffs = (
-            int(pricing_visual["great_high"]),
-            int(pricing_visual["good_high"]),
-            int(pricing_visual["fair_high"]),
-            int(pricing_visual["poor_high"]),
-        )
-        adjusted_position = evidence_adjusted_price(
-            int(listing["price"]), raw_risk, int(assessment[2])
-        )
-        scale_low = int(pricing_visual["scale_low"])
-        scale_high = int(pricing_visual["scale_high"])
-        pricing_visual["marker_pct"] = max(
-            0.0,
-            min(
-                100.0,
-                (adjusted_position - scale_low) / max(scale_high - scale_low, 1) * 100,
-            ),
-        )
-        pricing_visual["deal_score"] = deal_score_from_position(
+        price_score = deal_score_from_position(
             float(pricing_visual["marker_pct"]), deal
         )
+        if price_score is None:
+            pricing_visual["deal_score"] = None
+            narrative.append("Deal remains Suspicious because its price is outside the reliable comparison range.")
+        else:
+            pricing_visual["deal_score"] = int(
+                calculate_deal_score(price_score, raw_risk, favorable_evidence)
+            )
+            price_deal = deal
+            deal = deal_rating_from_score(float(pricing_visual["deal_score"]))
+            narrative.append(
+                f"Deal Score is {pricing_visual['deal_score']:.0f}%: price starts at {price_score:.0f}%, "
+                f"risk is {raw_risk:.1f}/10, and favorable evidence contributes "
+                f"{favorable_evidence_bonus(favorable_evidence, raw_risk):.0f} points."
+            )
+            if deal != price_deal:
+                narrative.append(
+                    f"The combined score changes the price-only rating from {price_deal} to {deal}."
+                )
         lc.deal_rating = deal
         lc.narrative = narrative
 

--- a/analysis/level2.py
+++ b/analysis/level2.py
@@ -16,6 +16,37 @@ from utils.carfax_parser import get_carfax_data
 from utils.models import CarfaxData
 
 
+def _listing_key(listing: dict) -> str:
+    return str(listing.get("id") or listing.get("vin") or "")
+
+
+def _price_assessment(lc, narrative: list[str]) -> tuple[str, int, int, float] | None:
+    listing = lc.listing
+    price_val = listing.get("price")
+    if price_val is None:
+        return None
+
+    price = int(price_val)
+    fpp_natl = int(lc.pricing.fpp_natl or 0)
+    fpp_local = int(lc.pricing.fpp_local or 0)
+    fmr_high = int(lc.pricing.fmr_high or 0)
+    fmv = int(lc.pricing.fmv or 0)
+    if not (fpp_natl and fpp_local and fmv):
+        return None
+
+    narrative.append(f"This vehicle is being listed at ${price}.")
+    best_comparison = determine_best_price(price, fpp_local, fpp_natl, fmv, narrative)
+    deal, midpoint, increment, percent = classify_deal_rating(
+        price, best_comparison, fmv, fpp_local, fmr_high
+    )
+    narrative.append(
+        f"Deal bins are set at ${increment * 2} ({percent * 200}%) in size, placing the Fair midpoint at ${midpoint}."
+    )
+    if deal == "Great" and midpoint and price < midpoint - increment * 3:
+        deal = "Suspicious"
+    return deal, midpoint, increment, percent
+
+
 def report_stats(label: str, values: list[float]):
     if not values:
         return f"{label}: no data\n"
@@ -34,52 +65,32 @@ def report_stats(label: str, values: list[float]):
 async def start_level2_analysis(metadata: dict, listings: list[dict], filename: str):
     ctx = await prepare_level2_analysis(metadata, listings, filename)
 
-    if len(ctx.listings) == 0:
-        print("No listings met the criteria for level 2 analysis.")
-        return None
-
     # listing, deal, risk, narrative
     ratings: list[tuple[dict, str, int, list[str]]] = []
+    # listing, price assessment, narrative
+    price_only: list[tuple[dict, str, list[str]]] = []
+    # listing, concrete reason
+    information_only: list[tuple[dict, str]] = []
 
     # Extract Carfax report
     for lc in sorted(ctx.listings, key=lambda x: str(x.listing.get("id", ""))):
         listing = lc.listing
-        price_val = listing.get("price")
-        if price_val is None:
-            continue
-
         report = Path(lc.report_path) if lc.report_path else None
-        if report is None or not report.exists():
-            continue
-
         narrative: list[str] = []
-
-        price = int(price_val)
-        fpp_natl = int(lc.pricing.fpp_natl or 0)
-        fpp_local = int(lc.pricing.fpp_local or 0)
-        fmr_high = int(lc.pricing.fmr_high or 0)
-        fmv = int(lc.pricing.fmv or 0)
-
-        if not (fpp_natl and fpp_local and fmv):
-            narrative.append(
-                "Unable to provide ratings for this vehicle: no pricing data is available for this vehicle."
+        assessment = _price_assessment(lc, narrative)
+        if assessment is None:
+            information_only.append(
+                (listing, "Complete KBB pricing is unavailable for this configuration.")
             )
             continue
 
-        # Initial deal ratings
-        narrative.append(f"This vehicle is being listed at ${price}.")
-        best_comparison = determine_best_price(
-            price, fpp_local, fpp_natl, fmv, narrative
-        )
-
-        deal, midpoint, increment, percent = classify_deal_rating(
-            price, best_comparison, fmv, fpp_local, fmr_high
-        )
-        narrative.append(
-            f"Deal bins are set at ${increment * 2} ({percent * 200}%) in size, placing the Fair midpoint at ${midpoint}."
-        )
-        if deal == "Great" and midpoint and price < midpoint - increment * 3:
-            deal = "Suspicious"
+        deal = assessment[0]
+        if report is None or not report.exists():
+            narrative.append(
+                "A vehicle-history report was not collected, so risk and the final Level 2 rating are unavailable."
+            )
+            price_only.append((listing, deal, narrative))
+            continue
 
         # Risk ratings and deal adjustment
         carfax: CarfaxData = get_carfax_data(report)
@@ -94,8 +105,35 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
 
         ratings.append((listing, deal, risk, narrative))
 
+    for listing in ctx.skipped_listings:
+        reason = (
+            "Listing price is unavailable."
+            if not listing.get("price")
+            else "The listing trim could not be mapped to compatible KBB pricing."
+        )
+        information_only.append((listing, reason))
+
+    accounted = len(ratings) + len(price_only) + len(information_only)
+    if accounted != len(listings):
+        seen = {
+            _listing_key(item[0])
+            for group in (ratings, price_only, information_only)
+            for item in group
+        }
+        for listing in listings:
+            if _listing_key(listing) not in seen:
+                information_only.append(
+                    (listing, "The listing could not be prepared for Level 2 analysis.")
+                )
+
     await render_level2_pdf(
-        ctx.make, ctx.model, len(listings), len(ctx.listings), ratings, metadata
+        ctx.make,
+        ctx.model,
+        len(listings),
+        ratings,
+        price_only,
+        information_only,
+        metadata,
     )
 
 

--- a/analysis/level2.py
+++ b/analysis/level2.py
@@ -6,9 +6,10 @@ from analysis.analysis_utils import get_report_dir
 from analysis.reporting import render_level2_pdf
 from analysis.scoring import (
     adjust_deal_for_risk,
+    calculate_risk_level2,
     classify_deal_rating,
     determine_best_price,
-    rate_risk_level2,
+    supports_deal_upgrade,
 )
 from analysis.workflow import prepare_level2_analysis
 
@@ -140,10 +141,16 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
         carfax: CarfaxData = get_carfax_data(report)
         lc.carfax = carfax
 
-        risk = rate_risk_level2(carfax, listing, narrative)
+        raw_risk = calculate_risk_level2(carfax, listing, narrative)
+        risk = round(max(min(raw_risk, 10.0), 0.0))
         lc.risk_score = risk
 
-        deal = adjust_deal_for_risk(deal, risk, narrative)
+        deal = adjust_deal_for_risk(
+            deal,
+            risk,
+            narrative,
+            favorable_evidence=supports_deal_upgrade(raw_risk),
+        )
         lc.deal_rating = deal
         lc.narrative = narrative
 

--- a/analysis/level2.py
+++ b/analysis/level2.py
@@ -20,7 +20,9 @@ def _listing_key(listing: dict) -> str:
     return str(listing.get("id") or listing.get("vin") or "")
 
 
-def _price_assessment(lc, narrative: list[str]) -> tuple[str, int, int, float] | None:
+def _price_assessment(
+    lc, narrative: list[str]
+) -> tuple[str, int, int, float, dict[str, int | float]] | None:
     listing = lc.listing
     price_val = listing.get("price")
     if price_val is None:
@@ -34,17 +36,58 @@ def _price_assessment(lc, narrative: list[str]) -> tuple[str, int, int, float] |
     if not (fpp_natl and fpp_local and fmv):
         return None
 
-    narrative.append(f"This vehicle is being listed at ${price}.")
     best_comparison = determine_best_price(price, fpp_local, fpp_natl, fmv, narrative)
     deal, midpoint, increment, percent = classify_deal_rating(
         price, best_comparison, fmv, fpp_local, fmr_high
     )
-    narrative.append(
-        f"Deal bins are set at ${increment * 2} ({percent * 200}%) in size, placing the Fair midpoint at ${midpoint}."
-    )
     if deal == "Great" and midpoint and price < midpoint - increment * 3:
         deal = "Suspicious"
-    return deal, midpoint, increment, percent
+
+    boundaries = [
+        midpoint - increment * 3,
+        midpoint - increment,
+        midpoint + increment,
+        midpoint + increment * 3,
+    ]
+    if best_comparison != fpp_local:
+        percentage_boundaries = [
+            round(midpoint * (1 - percent * 3)),
+            round(midpoint * (1 - percent)),
+            round(midpoint * (1 + percent)),
+            round(midpoint * (1 + percent * 3)),
+        ]
+        boundaries = [
+            max(absolute, percentage)
+            for absolute, percentage in zip(boundaries, percentage_boundaries)
+        ]
+
+    great_high, good_high, fair_high, poor_high = boundaries
+    leading_width = max(good_high - great_high, 1)
+    trailing_width = max(poor_high - fair_high, 1)
+    scale_low = max(great_high - leading_width, 0)
+    scale_high = poor_high + trailing_width
+    scale_width = max(scale_high - scale_low, 1)
+    marker_pct = max(0.0, min(100.0, (price - scale_low) / scale_width * 100))
+
+    boundary_percentages = [
+        (boundary - scale_low) / scale_width * 100 for boundary in boundaries
+    ]
+    great_end_pct, good_end_pct, fair_end_pct, poor_end_pct = boundary_percentages
+
+    pricing_visual: dict[str, int | float] = {
+        "listing_price": price,
+        "fair_low": good_high,
+        "fair_high": fair_high,
+        "great_high": great_high,
+        "good_high": good_high,
+        "poor_high": poor_high,
+        "marker_pct": marker_pct,
+        "great_end_pct": great_end_pct,
+        "good_end_pct": good_end_pct,
+        "fair_end_pct": fair_end_pct,
+        "poor_end_pct": poor_end_pct,
+    }
+    return deal, midpoint, increment, percent, pricing_visual
 
 
 def report_stats(label: str, values: list[float]):
@@ -91,6 +134,7 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
             )
             price_only.append((listing, deal, narrative))
             continue
+        pricing_visual = assessment[4]
 
         # Risk ratings and deal adjustment
         carfax: CarfaxData = get_carfax_data(report)
@@ -103,7 +147,7 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
         lc.deal_rating = deal
         lc.narrative = narrative
 
-        ratings.append((listing, deal, risk, narrative))
+        ratings.append((listing, deal, risk, narrative, pricing_visual))
 
     for listing in ctx.skipped_listings:
         reason = (

--- a/analysis/level3.py
+++ b/analysis/level3.py
@@ -70,9 +70,6 @@ async def start_level3_analysis(metadata: dict, listings: list[dict], filename: 
         narrative.append(
             f"Deal bins are set at ${increment * 2} ({percent * 200}%) in size, placing the Fair midpoint at ${midpoint}."
         )
-        if deal == "Great" and midpoint and price < midpoint - increment * 3:
-            deal = "Suspicious"
-
         # Risk ratings and deal adjustment
         carfax: CarfaxData = get_carfax_data(report)
         risk = rate_risk_level2(carfax, listing, narrative)

--- a/analysis/normalization.py
+++ b/analysis/normalization.py
@@ -264,6 +264,9 @@ def filter_valid_listings(
     for l in listings:
         # No analysis for listings with no price
         if not l.get("price"):
+            skipped_listings.append(l)
+            title = l.get("title", "Unknown")
+            skip_summary[title]["Listing price is unavailable."] += 1
             continue
 
         year = str(l["year"])

--- a/analysis/reporting.py
+++ b/analysis/reporting.py
@@ -176,35 +176,17 @@ async def render_level1_pdf(
     print(f"PDF created at: {out_file.resolve()}")
 
 
-def build_level2_bins(ratings: list) -> tuple[list, list, list, int, int, int]:
-    great_bin = []
-    good_bin = []
-    fair_bin = []
-    poor_count = 0
-    bad_count = 0
-    suspicious_count = 0
+def build_level2_bins(ratings: list) -> dict[str, list]:
+    bins = {name: [] for name in ("Great", "Good", "Fair", "Poor", "Bad", "Suspicious")}
 
     # 0 - listing, 1 - deal, 2 - risk, 3 - narrative
     for rating in ratings:
-        if rating[1] == "Great":
-            great_bin.append(rating)
-        elif rating[1] == "Good":
-            good_bin.append(rating)
-        elif rating[1] == "Fair":
-            fair_bin.append(rating)
-        elif rating[1] == "Poor":
-            poor_count += 1
-        elif rating[1] == "Bad":
-            bad_count += 1
-        else:
-            suspicious_count += 1
+        bins.get(rating[1], bins["Suspicious"]).append(rating)
 
     # Re-order bins by risk score
-    great_bin = sorted(great_bin, key=lambda r: (r[2], r[0].get("price")))
-    good_bin = sorted(good_bin, key=lambda r: (r[2], r[0].get("price")))
-    fair_bin = sorted(fair_bin, key=lambda r: (r[2], r[0].get("price")))
-
-    return great_bin, good_bin, fair_bin, poor_count, bad_count, suspicious_count
+    for name in bins:
+        bins[name] = sorted(bins[name], key=lambda r: (r[2], r[0].get("price") or 0))
+    return bins
 
 
 def shrink_image(path: str, max_width=500):
@@ -253,10 +235,10 @@ def get_images_for_listing(listing: dict) -> list[str]:
     return [encode_image_base64(str(p)) for p in paths[:3]]
 
 
-def collect_all_images(great_bin: list, good_bin: list, fair_bin: list) -> dict:
+def collect_all_images(rating_bins: dict[str, list]) -> dict:
     all_imgs = {}
 
-    for bin_data in (great_bin, good_bin, fair_bin):
+    for bin_data in rating_bins.values():
         for rating in bin_data:
             listing = rating[0]
             vin = listing.get("vin")
@@ -272,8 +254,9 @@ async def render_level2_pdf(
     make: str,
     model: str,
     total_count: int,
-    valid_count: int,
     ratings: list,
+    price_only: list,
+    information_only: list,
     metadata: dict,
 ):
     env = Environment(loader=FileSystemLoader("templates"))
@@ -282,11 +265,8 @@ async def render_level2_pdf(
     report_title = f"{make} {model} Market Overview — Level 2"
     generated_at = datetime.now().strftime("%B %d, %Y %I:%M %p")
 
-    great_bin, good_bin, fair_bin, poor_count, bad_count, sus_count = build_level2_bins(
-        ratings
-    )
-
-    all_images = collect_all_images(great_bin, good_bin, fair_bin)
+    rating_bins = build_level2_bins(ratings)
+    all_images = collect_all_images(rating_bins)
 
     summary = create_report_filter_summary(metadata)
     html_out = template.render(
@@ -296,13 +276,16 @@ async def render_level2_pdf(
         generated_at=generated_at,
         summary=summary,
         total_count=total_count,
-        valid_count=valid_count,
-        great_bin=great_bin,
-        good_bin=good_bin,
-        fair_bin=fair_bin,
-        poor_count=poor_count,
-        bad_count=bad_count,
-        sus_count=sus_count,
+        full_count=len(ratings),
+        price_only=sorted(price_only, key=lambda item: item[0].get("price") or 0),
+        information_only=information_only,
+        rating_bins=rating_bins,
+        great_bin=rating_bins["Great"],
+        good_bin=rating_bins["Good"],
+        fair_bin=rating_bins["Fair"],
+        poor_count=len(rating_bins["Poor"]),
+        bad_count=len(rating_bins["Bad"]),
+        sus_count=len(rating_bins["Suspicious"]),
         all_images=all_images,
     )
 

--- a/analysis/reporting.py
+++ b/analysis/reporting.py
@@ -173,7 +173,7 @@ async def render_level1_pdf(
         await page.pdf(path=str(out_file), format="A4", print_background=True)
         await browser.close()
 
-    print(f"✅ PDF created at: {out_file.resolve()}")
+    print(f"PDF created at: {out_file.resolve()}")
 
 
 def build_level2_bins(ratings: list) -> tuple[list, list, list, int, int, int]:
@@ -330,4 +330,4 @@ async def render_level2_pdf(
         await page.pdf(path=str(out_file), format="A4", print_background=True)
         await browser.close()
 
-    print(f"✅ PDF created at: {out_file.resolve()}")
+    print(f"PDF created at: {out_file.resolve()}")

--- a/analysis/reporting.py
+++ b/analysis/reporting.py
@@ -189,9 +189,16 @@ def build_level2_bins(ratings: list) -> dict[str, list]:
     for rating in ratings:
         bins.get(rating[1], bins["Suspicious"]).append(rating)
 
-    # Re-order bins by risk score
+    # Show the strongest listing first within each rating.
     for name in bins:
-        bins[name] = sorted(bins[name], key=lambda r: (r[2], r[0].get("price") or 0))
+        bins[name] = sorted(
+            bins[name],
+            key=lambda r: (
+                -(r[4].get("deal_strength") or 0) if len(r) > 4 else 0,
+                r[2],
+                r[0].get("price") or 0,
+            ),
+        )
     return bins
 
 
@@ -348,7 +355,7 @@ async def render_level2_pdf(
         await page.set_content(html_out, wait_until="load")
         await page.add_style_tag(path=str(css_path))
         await page.eval_on_selector_all(
-            "[data-left-pct], [data-width-pct], [data-height-pct]",
+            "[data-left-pct], [data-width-pct], [data-bottom-pct]",
             """elements => elements.forEach(element => {
                 if (element.dataset.leftPct !== undefined) {
                     element.style.left = `${element.dataset.leftPct}%`;
@@ -356,8 +363,8 @@ async def render_level2_pdf(
                 if (element.dataset.widthPct !== undefined) {
                     element.style.width = `${element.dataset.widthPct}%`;
                 }
-                if (element.dataset.heightPct !== undefined) {
-                    element.style.height = `${element.dataset.heightPct}%`;
+                if (element.dataset.bottomPct !== undefined) {
+                    element.style.bottom = `${element.dataset.bottomPct}%`;
                 }
             })""",
         )

--- a/analysis/reporting.py
+++ b/analysis/reporting.py
@@ -348,7 +348,7 @@ async def render_level2_pdf(
         await page.set_content(html_out, wait_until="load")
         await page.add_style_tag(path=str(css_path))
         await page.eval_on_selector_all(
-            "[data-left-pct], [data-width-pct]",
+            "[data-left-pct], [data-width-pct], [data-height-pct]",
             """elements => elements.forEach(element => {
                 if (element.dataset.leftPct !== undefined) {
                     element.style.left = `${element.dataset.leftPct}%`;
@@ -356,6 +356,19 @@ async def render_level2_pdf(
                 if (element.dataset.widthPct !== undefined) {
                     element.style.width = `${element.dataset.widthPct}%`;
                 }
+                if (element.dataset.heightPct !== undefined) {
+                    element.style.height = `${element.dataset.heightPct}%`;
+                }
+            })""",
+        )
+        await page.eval_on_selector_all(
+            ".price-track",
+            """tracks => tracks.forEach(track => {
+                const great = track.dataset.greatEndPct;
+                const good = track.dataset.goodEndPct;
+                const fair = track.dataset.fairEndPct;
+                const poor = track.dataset.poorEndPct;
+                track.style.background = `linear-gradient(90deg, #2f855a 0%, #4d8fb8 ${great}%, #d9bd4a ${good}%, #d47736 ${fair}%, #c2413b ${poor}%, #c2413b 100%)`;
             })""",
         )
         await page.pdf(path=str(out_file), format="A4", print_background=True)

--- a/analysis/reporting.py
+++ b/analysis/reporting.py
@@ -215,6 +215,13 @@ def display_dealer_location(value: str | None) -> str:
     return re.sub(r"\s+\d{5}(?:-\d{4})?$", "", value).strip()
 
 
+def display_listing_condition(value: str | None) -> str:
+    """Return a compact, user-facing condition label without inferring a value."""
+    if not value:
+        return "Unknown"
+    return "CPO" if value.casefold() in {"certified", "cpo"} else value.title()
+
+
 def logo_data_uri(path: Path) -> str | None:
     try:
         encoded = base64.b64encode(path.read_bytes()).decode("ascii")
@@ -324,6 +331,7 @@ async def render_level2_pdf(
         rating_bins=rating_bins,
         all_ratings=all_ratings,
         display_dealer_location=display_dealer_location,
+        display_listing_condition=display_listing_condition,
         great_bin=rating_bins["Great"],
         good_bin=rating_bins["Good"],
         fair_bin=rating_bins["Fair"],

--- a/analysis/reporting.py
+++ b/analysis/reporting.py
@@ -183,11 +183,11 @@ async def render_level1_pdf(
 
 
 def build_level2_bins(ratings: list) -> dict[str, list]:
-    bins = {name: [] for name in ("Great", "Good", "Fair", "Poor", "Bad", "Suspicious")}
+    bins = {name: [] for name in ("Great", "Good", "Fair", "Poor", "Bad")}
 
     # 0 - listing, 1 - deal, 2 - risk, 3 - narrative
     for rating in ratings:
-        bins.get(rating[1], bins["Suspicious"]).append(rating)
+        bins.get(rating[1], bins["Bad"]).append(rating)
 
     # Show the strongest listing first within each rating.
     for name in bins:
@@ -309,7 +309,7 @@ async def render_level2_pdf(
     rating_bins = build_level2_bins(ratings)
     all_ratings = [
         rating
-        for name in ("Great", "Good", "Fair", "Poor", "Bad", "Suspicious")
+        for name in ("Great", "Good", "Fair", "Poor", "Bad")
         for rating in rating_bins[name]
     ]
     all_images = collect_all_images(rating_bins)
@@ -337,7 +337,6 @@ async def render_level2_pdf(
         fair_bin=rating_bins["Fair"],
         poor_count=len(rating_bins["Poor"]),
         bad_count=len(rating_bins["Bad"]),
-        sus_count=len(rating_bins["Suspicious"]),
         all_images=all_images,
     )
 

--- a/analysis/reporting.py
+++ b/analysis/reporting.py
@@ -347,6 +347,17 @@ async def render_level2_pdf(
         await page.emulate_media(media="screen")
         await page.set_content(html_out, wait_until="load")
         await page.add_style_tag(path=str(css_path))
+        await page.eval_on_selector_all(
+            "[data-left-pct], [data-width-pct]",
+            """elements => elements.forEach(element => {
+                if (element.dataset.leftPct !== undefined) {
+                    element.style.left = `${element.dataset.leftPct}%`;
+                }
+                if (element.dataset.widthPct !== undefined) {
+                    element.style.width = `${element.dataset.widthPct}%`;
+                }
+            })""",
+        )
         await page.pdf(path=str(out_file), format="A4", print_background=True)
         await browser.close()
 

--- a/analysis/reporting.py
+++ b/analysis/reporting.py
@@ -1,5 +1,6 @@
-import base64, sys, urllib.parse
+import base64, re, sys, urllib.parse
 
+from collections import Counter
 from datetime import datetime
 from jinja2 import Environment, FileSystemLoader
 from pathlib import Path
@@ -48,8 +49,7 @@ def to_level1_json(
 
 def create_report_filter_summary(metadata: dict) -> str:
     """
-    Creates a summary header for the level 1 analysis report that briefly goes over which parameters that were used in the search.
-    This include condition, price filters, mileage filters, and the sort method
+	Creates a report header summarizing condition, price, mileage, and sort filters.
     """
 
     summary = "This report reflects{condition_summary}listings retrieved using the <i>{sort_method}</i> sort option"
@@ -58,7 +58,12 @@ def create_report_filter_summary(metadata: dict) -> str:
     miles_summary = ""
     filters = metadata["filters"]
     sort_method = filters.get("sort")  # this will always exist
-    condition: list[str] = filters.get("car_type")
+    raw_condition = filters.get("car_type")
+    condition = (
+        [raw_condition]
+        if isinstance(raw_condition, str)
+        else list(raw_condition or [])
+    )
     min_price: int = filters.get("price_min")
     max_price: int = filters.get("price_max")
     min_miles: int = filters.get("miles_min")
@@ -66,9 +71,9 @@ def create_report_filter_summary(metadata: dict) -> str:
 
     if condition:
         if len(condition) == 1:
-            condition_summary = f" {condition[0]} "
+            condition_summary = f" {condition[0].title()} "
         elif len(condition) == 2:
-            sort_cond = sorted(condition)
+            sort_cond = sorted(item.title() for item in condition)
             condition_summary = f" {sort_cond[0]} and {sort_cond[1]} "
         else:
             condition_summary = " New, Used, and Certified "
@@ -135,6 +140,7 @@ async def render_level1_pdf(
 
     html_out = template.render(
         report_title=report_title,
+        logo_svg=Path("img/deallens-logo.svg").read_text(encoding="utf-8"),
         generated_at=generated_at,
         summary=summary,
         cache_entries=cache_entries,
@@ -187,6 +193,27 @@ def build_level2_bins(ratings: list) -> dict[str, list]:
     for name in bins:
         bins[name] = sorted(bins[name], key=lambda r: (r[2], r[0].get("price") or 0))
     return bins
+
+
+def summarize_level2_failures(price_only: list, information_only: list) -> list[tuple[str, int]]:
+    counts = Counter(reason for _, reason in information_only)
+    if price_only:
+        counts["Vehicle-history report unavailable."] += len(price_only)
+    return sorted(counts.items())
+
+
+def display_dealer_location(value: str | None) -> str:
+    if not value:
+        return "N/A"
+    return re.sub(r"\s+\d{5}(?:-\d{4})?$", "", value).strip()
+
+
+def logo_data_uri(path: Path) -> str | None:
+    try:
+        encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+    except OSError:
+        return None
+    return f"data:image/svg+xml;base64,{encoded}"
 
 
 def shrink_image(path: str, max_width=500):
@@ -266,20 +293,30 @@ async def render_level2_pdf(
     generated_at = datetime.now().strftime("%B %d, %Y %I:%M %p")
 
     rating_bins = build_level2_bins(ratings)
+    all_ratings = [
+        rating
+        for name in ("Great", "Good", "Fair", "Poor", "Bad", "Suspicious")
+        for rating in rating_bins[name]
+    ]
     all_images = collect_all_images(rating_bins)
+    information_summary = summarize_level2_failures(price_only, information_only)
 
     summary = create_report_filter_summary(metadata)
     html_out = template.render(
         make=make,
         model=model,
         report_title=report_title,
+        logo=logo_data_uri(Path("img/deallens-logo.svg")),
         generated_at=generated_at,
         summary=summary,
         total_count=total_count,
         full_count=len(ratings),
         price_only=sorted(price_only, key=lambda item: item[0].get("price") or 0),
         information_only=information_only,
+        information_summary=information_summary,
         rating_bins=rating_bins,
+        all_ratings=all_ratings,
+        display_dealer_location=display_dealer_location,
         great_bin=rating_bins["Great"],
         good_bin=rating_bins["Good"],
         fair_bin=rating_bins["Fair"],

--- a/analysis/reporting.py
+++ b/analysis/reporting.py
@@ -194,7 +194,7 @@ def build_level2_bins(ratings: list) -> dict[str, list]:
         bins[name] = sorted(
             bins[name],
             key=lambda r: (
-                -(r[4].get("deal_strength") or 0) if len(r) > 4 else 0,
+                -(r[4].get("deal_score") or 0) if len(r) > 4 else 0,
                 r[2],
                 r[0].get("price") or 0,
             ),

--- a/analysis/scoring.py
+++ b/analysis/scoring.py
@@ -585,32 +585,46 @@ def score_warranty_status(
     """
     basic_months: int = 0
     basic_miles: int = 0
-    coverages: list[dict] = listing["coverages"]
+    coverages: list[dict] = listing.get("coverages", [])
+    basic = next((c for c in coverages if c.get("type") == "Basic"), None)
+    warranty_text = str(carfax.additional_history.get("Basic Warranty", "")).strip()
+
+    if not warranty_text and basic is None:
+        if narrative is not None:
+            narrative.append(
+                "Basic warranty information is unavailable; it does not affect scoring."
+            )
+        return 0.0
 
     if carfax.has_accident or carfax.has_damage:
         if narrative is not None:
             narrative.append("The basic warranty on this vehicle has been voided.")
         return 0.0
 
-    if not carfax.is_basic_warranty_active:
+    if warranty_text and not carfax.is_basic_warranty_active:
         if narrative is not None:
             narrative.append("The basic warranty on this vehicle has expired.")
         return 0.0
 
-    basic_months, basic_miles = carfax.remaining_warranty
+    if not warranty_text and basic and basic.get("status", "") == "Fully expired":
+        if narrative is not None:
+            narrative.append("The basic warranty on this vehicle has expired.")
+        return 0.0
+
+    if warranty_text:
+        basic_months, basic_miles = carfax.remaining_warranty
 
     if basic_months == 0 or basic_miles == 0:
-        basic = next((c for c in coverages if c.get("type") == "Basic"), None)
         if basic and basic.get("status", "") != "Fully expired":
             time_left = basic.get("time_left", "")
             year_pattern = re.compile(r"(\d+)\s+yr")
             match = year_pattern.search(time_left)
-            years = to_int(match[0] if match else 0)
+            years = to_int(match[0] if match else 0) or 0
 
             month_pattern = re.compile(r"(\d+)\s+mo")
             match = month_pattern.search(time_left)
-            months = to_int(match[0] if match else 0)
-            basic_months = (years * 12) + months if years and months else 0
+            months = to_int(match[0] if match else 0) or 0
+            basic_months = (years * 12) + months
 
             miles_nums = to_int(basic.get("miles_left", ""))
             basic_miles = miles_nums * 1000 if miles_nums else 0

--- a/analysis/scoring.py
+++ b/analysis/scoring.py
@@ -284,6 +284,13 @@ def evidence_adjusted_price(price: int, raw_risk: float, increment: int) -> int:
     return price + round(raw_risk * increment * RISK_PRICE_ADJUSTMENT_RATIO)
 
 
+def deal_score_from_position(marker_pct: float, deal: str) -> float | None:
+    """Convert the full price-scale position to a comparable 0-100 deal score."""
+    if deal == "Suspicious":
+        return None
+    return max(0.0, min(100.0, 100.0 - marker_pct))
+
+
 def deal_strength_within_bin(
     deal: str,
     adjusted_position: int,

--- a/analysis/scoring.py
+++ b/analysis/scoring.py
@@ -1,6 +1,7 @@
 import re
 import math
 
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
 
@@ -285,6 +286,18 @@ def risk_penalty(risk: float) -> float:
     )
 
 
+@dataclass(frozen=True)
+class DealScoreResult:
+    """Deterministic Level 2 score inputs and outputs, independent of prose."""
+
+    price_score: float
+    risk_score: float
+    risk_penalty: float
+    favorable_bonus: float
+    final_score: int
+    rating: str
+
+
 def calculate_deal_score(
     price_score: float,
     risk: float,
@@ -299,6 +312,27 @@ def calculate_deal_score(
     return max(0.0, min(100.0, max(score, low_risk_floor)))
 
 
+def calculate_deal_score_result(
+    price_score: float,
+    risk: float,
+    favorable_evidence: float = 0.0,
+) -> DealScoreResult:
+    """Return the complete pure calculation result used by reports and explanations."""
+    bounded_risk = max(0.0, min(10.0, risk))
+    price_risk_weight = 0.8 + 0.2 * (100.0 - price_score) / 100.0
+    applied_penalty = risk_penalty(bounded_risk) * price_risk_weight
+    bonus = favorable_evidence_bonus(favorable_evidence, bounded_risk)
+    final_score = int(calculate_deal_score(price_score, bounded_risk, favorable_evidence))
+    return DealScoreResult(
+        price_score=price_score,
+        risk_score=bounded_risk,
+        risk_penalty=applied_penalty,
+        favorable_bonus=bonus,
+        final_score=final_score,
+        rating=deal_rating_from_score(final_score),
+    )
+
+
 def favorable_evidence_bonus(favorable_evidence: float, risk: float) -> float:
     """Return a modest bonus that is fully negated by meaningful risk at 4+."""
     bounded_risk = max(0.0, min(10.0, risk))
@@ -309,21 +343,23 @@ def favorable_evidence_bonus(favorable_evidence: float, risk: float) -> float:
     )
 
 
-def format_deal_score_narrative(
-    score: float,
-    price_score: float,
-    risk: float,
-    favorable_bonus: float,
-) -> str:
+def format_deal_score_narrative(result: DealScoreResult) -> str:
     """Explain Deal Score inputs without displaying meaningless zero values."""
-    parts = [f"Deal Score is {score:.0f}%: price starts at {price_score:.0f}%"]
-    parts.append("no risk was identified" if risk <= 0 else f"risk is {risk:.1f}/10")
-    if favorable_bonus <= 0:
+    parts = [
+        f"Deal Score is {result.final_score}%: "
+        f"price starts at {result.price_score:.0f}%"
+    ]
+    parts.append(
+        "no risk was identified"
+        if result.risk_score <= 0
+        else f"risk is {result.risk_score:.1f}/10"
+    )
+    if result.favorable_bonus <= 0:
         parts.append("there is no favorable evidence")
-    elif favorable_bonus < 1:
+    elif result.favorable_bonus < 1:
         parts.append("favorable evidence adds less than 1 point")
     else:
-        rounded_bonus = round(favorable_bonus)
+        rounded_bonus = round(result.favorable_bonus)
         parts.append(
             f"favorable evidence adds {rounded_bonus} point"
             f"{'s' if rounded_bonus != 1 else ''}"

--- a/analysis/scoring.py
+++ b/analysis/scoring.py
@@ -182,7 +182,10 @@ def rate_risk_level1(listing, price, compare_value) -> str:
 
 
 def adjust_deal_for_risk(
-    base_bin: str, risk: float, narrative: Optional[list[str]] = None
+    base_bin: str,
+    risk: float,
+    narrative: Optional[list[str]] = None,
+    favorable_evidence: bool = False,
 ) -> str:
     """
     Adjusts deal grading for level 2 based on the risk.
@@ -199,7 +202,9 @@ def adjust_deal_for_risk(
         return "Suspicious"
 
     idx = DEAL_ORDER.index(base_bin)
-    if risk <= 2:
+    if risk == 0 and favorable_evidence:
+        shift = -1 if idx > 0 else 0
+    elif risk <= 2:
         shift = 0
     elif risk <= 4:
         shift = 1
@@ -214,10 +219,14 @@ def adjust_deal_for_risk(
             )
         return "Bad"
 
-    new_deal = DEAL_ORDER[min(idx + shift, len(DEAL_ORDER) - 1)]
+    new_deal = DEAL_ORDER[max(0, min(idx + shift, len(DEAL_ORDER) - 1))]
 
     if narrative is not None:
-        if shift == 0:
+        if shift < 0:
+            narrative.append(
+                f"Originally rated {base_bin} based on price alone, but is now upgraded to {new_deal} due to very low calculated risk."
+            )
+        elif shift == 0:
             narrative.append(
                 f"Deal rating is fixed at {base_bin} based on price and {"low" if risk else "no"} risk factors."
             )
@@ -229,9 +238,9 @@ def adjust_deal_for_risk(
     return new_deal
 
 
-def rate_risk_level2(
+def calculate_risk_level2(
     carfax: CarfaxData, listing: dict, narrative: Optional[list[str]] = None
-) -> int:
+) -> float:
     """
     Scores multiple areas of the carfax report to return a risk level
 
@@ -242,12 +251,26 @@ def rate_risk_level2(
         Listing data containing at least "year" and "mileage" fields.
 
     Returns:
-        float: A continuous risk modifier between 0.0 and 10.0.
+        float: The raw, unclamped risk score. Negative values represent favorable
+        evidence that can support a one-bin deal upgrade.
     """
     score: float = score_title_status(carfax, narrative)
     score += score_mileage_use(carfax, listing, narrative)
     score += score_warranty_status(carfax, listing, narrative)
+    return score
+
+
+def rate_risk_level2(
+    carfax: CarfaxData, listing: dict, narrative: Optional[list[str]] = None
+) -> int:
+    """Return the displayed 0-10 risk score after preserving raw evidence internally."""
+    score = calculate_risk_level2(carfax, listing, narrative)
     return round(max(min(score, 10.0), 0.0))
+
+
+def supports_deal_upgrade(raw_risk: float) -> bool:
+    """Require substantial favorable evidence before improving a price-based bin."""
+    return raw_risk <= -2.0
 
 
 def score_title_status(

--- a/analysis/scoring.py
+++ b/analysis/scoring.py
@@ -317,12 +317,12 @@ def calculate_deal_score(
 
 
 def favorable_evidence_bonus(favorable_evidence: float, risk: float) -> float:
-    """Return a modest bonus that fades as actual vehicle risk approaches 10."""
+    """Return a modest bonus that is fully negated by meaningful risk at 4+."""
     bounded_risk = max(0.0, min(10.0, risk))
     return (
         max(favorable_evidence, 0.0)
         * FAVORABLE_EVIDENCE_POINTS
-        * (1.0 - bounded_risk / 10.0)
+        * max(0.0, 1.0 - bounded_risk / 4.0)
     )
 
 

--- a/analysis/scoring.py
+++ b/analysis/scoring.py
@@ -326,6 +326,28 @@ def favorable_evidence_bonus(favorable_evidence: float, risk: float) -> float:
     )
 
 
+def format_deal_score_narrative(
+    score: float,
+    price_score: float,
+    risk: float,
+    favorable_bonus: float,
+) -> str:
+    """Explain Deal Score inputs without displaying meaningless zero values."""
+    parts = [f"Deal Score is {score:.0f}%: price starts at {price_score:.0f}%"]
+    parts.append("no risk was identified" if risk <= 0 else f"risk is {risk:.1f}/10")
+    if favorable_bonus <= 0:
+        parts.append("there is no favorable evidence")
+    elif favorable_bonus < 1:
+        parts.append("favorable evidence adds less than 1 point")
+    else:
+        rounded_bonus = round(favorable_bonus)
+        parts.append(
+            f"favorable evidence adds {rounded_bonus} point"
+            f"{'s' if rounded_bonus != 1 else ''}"
+        )
+    return ", ".join(parts) + "."
+
+
 def deal_rating_from_score(score: float) -> str:
     """Derive the displayed rating from the final continuous Deal Score."""
     if score >= 80:
@@ -613,20 +635,15 @@ def score_warranty_status(
             miles_nums = to_int(basic.get("miles_left", ""))
             basic_miles = miles_nums * 1000 if miles_nums else 0
 
-    if basic_months > 12 and basic_miles > 12000:
-        rating = -2.0
-    elif basic_months > 12 or basic_miles > 12000:
-        rating = -1.5
-    elif basic_months > 6 or basic_miles > 6000:
-        rating = -1.0
-    elif basic_months > 0 and basic_miles > 0:
-        rating = -0.5
-    else:
-        rating = 0.0
+    miles_per_month = 15000 / 12
+    mileage_months = basic_miles / miles_per_month if basic_miles > 0 else 0.0
+    effective_months = min(float(basic_months), mileage_months)
+    rating = -min(effective_months / 6.0, 2.0) if effective_months > 0 else 0.0
 
     if rating and narrative is not None:
         narrative.append(
-            f"Basic warranty is active with {basic_months} months left and {basic_miles} miles left."
+            f"Basic warranty is active with {basic_months} months left and {basic_miles} miles left; "
+            f"at 15,000 miles per year, the limiting coverage is about {effective_months:.1f} months."
         )
 
     return rating
@@ -685,32 +702,32 @@ def score_mileage_use(
     if deviation <= -0.20:
         if narrative is not None:
             narrative.append(
-                f"Vehicle has been driven significantly less than expected for it's age ({percent_diff:.1f}%)."
+                f"Vehicle has been driven significantly less than expected for its age ({percent_diff:.1f}%)."
             )
         score = -1.0
     elif deviation <= -0.10:
         if narrative is not None:
             narrative.append(
-                f"Vehicle has been driven less than expected for it's age ({percent_diff:.1f}%)."
+                f"Vehicle has been driven less than expected for its age ({percent_diff:.1f}%)."
             )
         score = -1.0 + (deviation + 0.20) * 5  # smooth ramp -1 → -0.5
     elif deviation < 0.10:
         if narrative is not None:
             narrative.append(
-                f"Vehicle has been driven an expected amount for it's age."
+                "Vehicle has been driven an expected amount for its age."
             )
         score = 0.0
     elif deviation < 0.40:
         if narrative is not None:
             narrative.append(
-                f"Vehicle has been driven more than expected for it's age ({percent_diff:.1f}%)."
+                f"Vehicle has been driven more than expected for its age ({percent_diff:.1f}%)."
             )
         # from +10% → +40%, interpolate 0 → 2.0
         score = ((deviation - 0.10) / 0.30) * 2.0
     else:
         if narrative is not None:
             narrative.append(
-                f"Vehicle has been driven much more than expected for it's age ({percent_diff:.1f}%)."
+                f"Vehicle has been driven much more than expected for its age ({percent_diff:.1f}%)."
             )
         score = 2.0
 

--- a/analysis/scoring.py
+++ b/analysis/scoring.py
@@ -193,17 +193,6 @@ def adjust_deal_for_risk(
     """
     Adjusts deal grading for level 2 based on the risk.
     """
-    if base_bin == "Suspicious":
-        if risk > 5:
-            if narrative is not None:
-                narrative.append(
-                    "Deal rating has been downgraded to Bad due to risk and suspicious pricing."
-                )
-            return "Bad"
-        if narrative is not None:
-            narrative.append("Deal is set as Suspicious due to extreme pricing.")
-        return "Suspicious"
-
     idx = DEAL_ORDER.index(base_bin)
     if risk <= 2:
         shift = 0
@@ -248,10 +237,6 @@ def adjust_deal_for_evidence(
     narrative: Optional[list[str]] = None,
 ) -> str:
     """Move the price position continuously, then classify only crossed cutoffs."""
-    displayed_risk = round(max(min(raw_risk, 10.0), 0.0))
-    if base_bin == "Suspicious":
-        return adjust_deal_for_risk(base_bin, displayed_risk, narrative)
-
     adjusted_position = evidence_adjusted_price(price, raw_risk, increment)
     evidence_adjustment = adjusted_position - price
     great_high, good_high, fair_high, poor_high = cutoffs
@@ -287,10 +272,8 @@ def evidence_adjusted_price(price: int, raw_risk: float, increment: int) -> int:
     return price + round(raw_risk * increment * RISK_PRICE_ADJUSTMENT_RATIO)
 
 
-def deal_score_from_position(marker_pct: float, deal: str) -> float | None:
+def deal_score_from_position(marker_pct: float) -> float:
     """Convert the full price-scale position to a comparable 0-100 deal score."""
-    if deal == "Suspicious":
-        return None
     return max(0.0, min(100.0, 100.0 - marker_pct))
 
 
@@ -367,9 +350,6 @@ def deal_strength_within_bin(
     cutoffs: tuple[int, int, int, int],
 ) -> float | None:
     """Return 0-100 position within a deal bin, where 100 is nearer a better bin."""
-    if deal == "Suspicious":
-        return None
-
     great_high, good_high, fair_high, poor_high = cutoffs
     leading_width = max(good_high - great_high, 1)
     trailing_width = max(poor_high - fair_high, 1)
@@ -580,7 +560,7 @@ def get_branded_score(
             narrative.append("Vehicle was declared a total loss.")
 
     if damage_score <= 0:
-        return 7.0  # suspicious: title issue with no visible damage
+        return 7.0  # anomalous: title issue with no visible damage
 
     scale = ((damage_score / 10) ** 1.3) * 1.05
     return 4.0 + min(scale, 1.0) * 5.0  # branded curve: 4 → 9

--- a/analysis/scoring.py
+++ b/analysis/scoring.py
@@ -34,6 +34,7 @@ STRUCTURAL_SCORES: dict[StructuralStatus, float] = {
     StructuralStatus.POSSIBLE: 1.0,
     StructuralStatus.CONFIRMED: 2.5,
 }
+RISK_PRICE_ADJUSTMENT_RATIO = 0.6
 
 
 def rate_uncertainty(listing) -> str:
@@ -185,7 +186,6 @@ def adjust_deal_for_risk(
     base_bin: str,
     risk: float,
     narrative: Optional[list[str]] = None,
-    favorable_evidence: bool = False,
 ) -> str:
     """
     Adjusts deal grading for level 2 based on the risk.
@@ -202,9 +202,7 @@ def adjust_deal_for_risk(
         return "Suspicious"
 
     idx = DEAL_ORDER.index(base_bin)
-    if risk == 0 and favorable_evidence:
-        shift = -1 if idx > 0 else 0
-    elif risk <= 2:
+    if risk <= 2:
         shift = 0
     elif risk <= 4:
         shift = 1
@@ -238,6 +236,49 @@ def adjust_deal_for_risk(
     return new_deal
 
 
+def adjust_deal_for_evidence(
+    base_bin: str,
+    raw_risk: float,
+    price: int,
+    increment: int,
+    cutoffs: tuple[int, int, int, int],
+    narrative: Optional[list[str]] = None,
+) -> str:
+    """Move the price position continuously, then classify only crossed cutoffs."""
+    displayed_risk = round(max(min(raw_risk, 10.0), 0.0))
+    if base_bin == "Suspicious":
+        return adjust_deal_for_risk(base_bin, displayed_risk, narrative)
+
+    evidence_adjustment = round(raw_risk * increment * RISK_PRICE_ADJUSTMENT_RATIO)
+    adjusted_position = price + evidence_adjustment
+    great_high, good_high, fair_high, poor_high = cutoffs
+
+    if adjusted_position <= great_high:
+        adjusted_bin = "Great"
+    elif adjusted_position <= good_high:
+        adjusted_bin = "Good"
+    elif adjusted_position <= fair_high:
+        adjusted_bin = "Fair"
+    elif adjusted_position <= poor_high:
+        adjusted_bin = "Poor"
+    else:
+        adjusted_bin = "Bad"
+
+    if narrative is not None:
+        amount = abs(evidence_adjustment)
+        if adjusted_bin == base_bin or evidence_adjustment == 0:
+            narrative.append(
+                f"Deal rating remains {base_bin}; available vehicle-history evidence changes its price position by only ${amount:,}."
+            )
+        else:
+            direction = "improves" if evidence_adjustment < 0 else "worsens"
+            narrative.append(
+                f"Available vehicle-history evidence {direction} the price position by ${amount:,}, changing the deal rating from {base_bin} to {adjusted_bin}."
+            )
+
+    return adjusted_bin
+
+
 def calculate_risk_level2(
     carfax: CarfaxData, listing: dict, narrative: Optional[list[str]] = None
 ) -> float:
@@ -252,7 +293,7 @@ def calculate_risk_level2(
 
     Returns:
         float: The raw, unclamped risk score. Negative values represent favorable
-        evidence that can support a one-bin deal upgrade.
+        evidence and positive values represent added risk.
     """
     score: float = score_title_status(carfax, narrative)
     score += score_mileage_use(carfax, listing, narrative)
@@ -266,11 +307,6 @@ def rate_risk_level2(
     """Return the displayed 0-10 risk score after preserving raw evidence internally."""
     score = calculate_risk_level2(carfax, listing, narrative)
     return round(max(min(score, 10.0), 0.0))
-
-
-def supports_deal_upgrade(raw_risk: float) -> bool:
-    """Require substantial favorable evidence before improving a price-based bin."""
-    return raw_risk <= -2.0
 
 
 def score_title_status(
@@ -376,7 +412,7 @@ def get_structure_score(
             )
         if status == StructuralStatus.POSSIBLE:
             narrative.append(
-                "At least one damage report alluded to possible structural problems."
+                "CARFAX recommends an inspection after reported damage; this does not confirm structural damage."
             )
 
     # Scale down to give more breathing room with the title

--- a/analysis/scoring.py
+++ b/analysis/scoring.py
@@ -249,8 +249,8 @@ def adjust_deal_for_evidence(
     if base_bin == "Suspicious":
         return adjust_deal_for_risk(base_bin, displayed_risk, narrative)
 
-    evidence_adjustment = round(raw_risk * increment * RISK_PRICE_ADJUSTMENT_RATIO)
-    adjusted_position = price + evidence_adjustment
+    adjusted_position = evidence_adjusted_price(price, raw_risk, increment)
+    evidence_adjustment = adjusted_position - price
     great_high, good_high, fair_high, poor_high = cutoffs
 
     if adjusted_position <= great_high:
@@ -277,6 +277,35 @@ def adjust_deal_for_evidence(
             )
 
     return adjusted_bin
+
+
+def evidence_adjusted_price(price: int, raw_risk: float, increment: int) -> int:
+    """Return a comparison position only; this never changes the listing price."""
+    return price + round(raw_risk * increment * RISK_PRICE_ADJUSTMENT_RATIO)
+
+
+def deal_strength_within_bin(
+    deal: str,
+    adjusted_position: int,
+    cutoffs: tuple[int, int, int, int],
+) -> float | None:
+    """Return 0-100 position within a deal bin, where 100 is nearer a better bin."""
+    if deal == "Suspicious":
+        return None
+
+    great_high, good_high, fair_high, poor_high = cutoffs
+    leading_width = max(good_high - great_high, 1)
+    trailing_width = max(poor_high - fair_high, 1)
+    bounds = {
+        "Great": (great_high - leading_width, great_high),
+        "Good": (great_high, good_high),
+        "Fair": (good_high, fair_high),
+        "Poor": (fair_high, poor_high),
+        "Bad": (poor_high, poor_high + trailing_width),
+    }
+    low, high = bounds[deal]
+    strength = (high - adjusted_position) / max(high - low, 1) * 100
+    return max(0.0, min(100.0, strength))
 
 
 def calculate_risk_level2(

--- a/analysis/scoring.py
+++ b/analysis/scoring.py
@@ -1,4 +1,5 @@
 import re
+import math
 
 from datetime import datetime
 from typing import Optional
@@ -35,6 +36,8 @@ STRUCTURAL_SCORES: dict[StructuralStatus, float] = {
     StructuralStatus.CONFIRMED: 2.5,
 }
 RISK_PRICE_ADJUSTMENT_RATIO = 0.6
+FAVORABLE_EVIDENCE_POINTS = 6.0
+MINIMUM_LOW_RISK_SCORE = 10.0
 
 
 def rate_uncertainty(listing) -> str:
@@ -291,6 +294,51 @@ def deal_score_from_position(marker_pct: float, deal: str) -> float | None:
     return max(0.0, min(100.0, 100.0 - marker_pct))
 
 
+def risk_penalty(risk: float) -> float:
+    """Return an exponential 0-100 penalty for an actual 0-10 risk score."""
+    bounded_risk = max(0.0, min(10.0, risk))
+    return 100.0 * (math.exp(bounded_risk / 4.0) - 1.0) / (
+        math.exp(2.5) - 1.0
+    )
+
+
+def calculate_deal_score(
+    price_score: float,
+    risk: float,
+    favorable_evidence: float = 0.0,
+) -> float:
+    """Combine linear price value, exponential risk, and modest evidence bonuses."""
+    bounded_risk = max(0.0, min(10.0, risk))
+    price_risk_weight = 0.8 + 0.2 * (100.0 - price_score) / 100.0
+    score = price_score - risk_penalty(bounded_risk) * price_risk_weight
+    score += favorable_evidence_bonus(favorable_evidence, bounded_risk)
+    low_risk_floor = MINIMUM_LOW_RISK_SCORE * (1.0 - bounded_risk / 10.0)
+    return max(0.0, min(100.0, max(score, low_risk_floor)))
+
+
+def favorable_evidence_bonus(favorable_evidence: float, risk: float) -> float:
+    """Return a modest bonus that fades as actual vehicle risk approaches 10."""
+    bounded_risk = max(0.0, min(10.0, risk))
+    return (
+        max(favorable_evidence, 0.0)
+        * FAVORABLE_EVIDENCE_POINTS
+        * (1.0 - bounded_risk / 10.0)
+    )
+
+
+def deal_rating_from_score(score: float) -> str:
+    """Derive the displayed rating from the final continuous Deal Score."""
+    if score >= 80:
+        return "Great"
+    if score >= 60:
+        return "Good"
+    if score >= 40:
+        return "Fair"
+    if score >= 20:
+        return "Poor"
+    return "Bad"
+
+
 def deal_strength_within_bin(
     deal: str,
     adjusted_position: int,
@@ -319,7 +367,7 @@ def calculate_risk_level2(
     carfax: CarfaxData, listing: dict, narrative: Optional[list[str]] = None
 ) -> float:
     """
-    Scores multiple areas of the carfax report to return a risk level
+    Score adverse evidence only; favorable evidence is handled separately.
 
     Parameters:
         carfax: CarfaxData
@@ -328,19 +376,30 @@ def calculate_risk_level2(
         Listing data containing at least "year" and "mileage" fields.
 
     Returns:
-        float: The raw, unclamped risk score. Negative values represent favorable
-        evidence and positive values represent added risk.
+        float: The actual risk score from 0 to 10.
     """
-    score: float = score_title_status(carfax, narrative)
-    score += score_mileage_use(carfax, listing, narrative)
-    score += score_warranty_status(carfax, listing, narrative)
-    return score
+    risk, _ = calculate_level2_evidence(carfax, listing, narrative)
+    return risk
+
+
+def calculate_level2_evidence(
+    carfax: CarfaxData,
+    listing: dict,
+    narrative: Optional[list[str]] = None,
+) -> tuple[float, float]:
+    """Return actual risk and favorable evidence as separate non-negative values."""
+    risk = score_title_status(carfax, narrative)
+    mileage = score_mileage_use(carfax, listing, narrative)
+    warranty = score_warranty_status(carfax, listing, narrative)
+    risk += max(mileage, 0.0)
+    favorable = max(-mileage, 0.0) + max(-warranty, 0.0)
+    return min(max(risk, 0.0), 10.0), favorable
 
 
 def rate_risk_level2(
     carfax: CarfaxData, listing: dict, narrative: Optional[list[str]] = None
 ) -> int:
-    """Return the displayed 0-10 risk score after preserving raw evidence internally."""
+    """Return the displayed 0-10 adverse-risk score."""
     score = calculate_risk_level2(carfax, listing, narrative)
     return round(max(min(score, 10.0), 0.0))
 

--- a/analysis/workflow.py
+++ b/analysis/workflow.py
@@ -121,15 +121,10 @@ async def prepare_level2_analysis(
 
     norm_listings = [normalize_listing(l) for l in listings]
 
-    filtered_listings = []
-    for vl in norm_listings:
-        report = get_report_dir(vl)
-        if report and report.exists():
-            filtered_listings.append(vl)
-
-    ctx = await prepare_level1_analysis(
-        metadata, norm_listings, filtered_listings, True
-    )
+    # Keep every listing in the Level 2 workflow. Report availability determines
+    # whether a listing receives a full risk-adjusted rating later; it should not
+    # determine whether the listing is represented in the report at all.
+    ctx = await prepare_level1_analysis(metadata, norm_listings, is_normalized=True)
 
     check_missing_docs(listings)
 

--- a/docs/visor-api-migration.md
+++ b/docs/visor-api-migration.md
@@ -114,6 +114,110 @@ The API does provide `days_on_market`, facet-level days-on-market statistics, a
 generic `vhr_url`, structured options, and build verification. These are related but
 are not interchangeable with the missing legacy fields.
 
+## Level 2 acquisition decision
+
+Level 2 should use one enriched listing search followed by standard vehicle-detail
+requests for the returned listings:
+
+1. Call `GET /v1/listings` with `include=options,price_history`, the required
+   listing projection, and a maximum page size of 100.
+2. Call `GET /v1/listings/{listing_id}` without expansions for each returned
+   listing.
+
+Do not set `inventory_type` unless the user selects one or more conditions. The
+default Level 2 search therefore includes new, used, and certified vehicles. Sorting
+can cause the first 100 results to contain only some of those conditions.
+
+This combination maps the usable legacy `scraper.py` listing fields:
+
+- stable ID and VIN;
+- year, make, model, trim, version, condition, price, and mileage;
+- listing age, dealer listing URL, and photos;
+- seller name, location, stock number, and phone when available;
+- normalized vehicle specifications;
+- installed options and price history.
+
+CARFAX, AutoCheck, and window-sticker URL discovery is not part of this Visor API
+acquisition decision. It remains supplemental dealer-site enrichment. The material
+legacy loss is Visor warranty status and coverage limits, which are not available
+from the Public API and are no longer reliably accessible through the paywalled web
+view. Record warranty evidence as unavailable unless a separate approved source
+provides it.
+
+### Cost
+
+The API's usage headers report these request classes and prices:
+
+| Request | Usage class | Cost |
+| --- | --- | ---: |
+| Enriched listing search, up to 100 returned listings | `listing_search_enriched` | $0.04 per request |
+| Standard listing detail | `vehicle_detail` | $0.003 per listing |
+
+A full 100-listing run therefore costs `$0.04 + (100 * $0.003) = $0.34`.
+Options and price history should not also be requested on every detail call because
+the enriched search already supplies them.
+
+### Live field audit
+
+An authenticated audit on 2026-07-21 requested 100 active 2024-2026 Subaru
+Crosstreks with at most 75,000 miles, sorted by price ascending. The search matched
+25,365 records and returned 100: 91 used and 9 certified. New inventory was not
+excluded; no new vehicle ranked among the lowest-priced 100 at collection time.
+
+All 100 search rows contained the core identity, price, mileage, condition, listing,
+dealer, photo, feature, option, and MSRP fields requested by the current projection.
+Decoded options were non-empty for 99, and price history was non-empty for 62.
+Standard detail succeeded for 89 before the account's rate limit exhausted bounded
+retries. For those 89 records, normalized build data was complete; dealer phone was
+available for 85, generic `vhr_url` for 21, and detailed provider pricing for 56.
+These counts describe one live audit and must not become fixture expectations.
+
+The audit also confirmed that standard detail returns `options` and `price_history`
+as unavailable when those expansions are omitted. The enriched search is therefore
+the least expensive place to obtain both for all listings.
+
+### Fields collected but not currently used by Level 2
+
+Preserve these fields in raw source data and provenance, but do not add them to
+Level 2 calculations merely because they are available:
+
+- MSRP and discount from MSRP;
+- normalized features and option-package codes;
+- installed-option values and price history;
+- provider pricing totals and line items;
+- generic VHR URL;
+- dealer phone and coordinates;
+- inventory, sold, and last-checked dates;
+- listing lifecycle and availability statuses;
+- assembly location and window-sticker verification;
+- base and combined MSRP;
+- colors, cylinders, doors, and seating capacity.
+
+### Rate limiting
+
+The current account tier advertises 10 requests per 10 seconds. A live batch with
+five concurrent detail workers still produced `429 rate_limit_exceeded` responses,
+so Level 2 must not assume that nominal throughput is continuously available. The
+shared API client already honors the response's `Retry-After` header and performs
+bounded retries. The Level 2 collection service should additionally serialize or
+centrally rate-limit detail requests so concurrent workers do not wake and retry as
+another burst.
+
+### Implemented collection boundary
+
+`visor_api.level2_service.collect_level2_listings` implements this acquisition
+plan. It delegates offset pagination to `VisorClient.filter_all_listings`, then
+retrieves standard detail sequentially for each unique stable listing ID. Search
+rows remain usable when detail fails; the record stores the sanitized detail error,
+an explicit warning, and unavailable provenance. Malformed rows, missing IDs, and
+duplicate IDs are retained as structured exclusions rather than disappearing.
+
+`visor_api.level2_cache.cached_level2_collection` stores the complete collection,
+including raw search/detail records and exclusions, in an atomic local daily cache.
+It supports forced refresh and invalidates corrupt, stale, or incompatible cache
+envelopes. This service is the Level 2 acquisition boundary only; routing the
+`--level2` CLI workflow through it remains a later integration task in issue #238.
+
 ## Market-overview source determination
 
 The current active-inventory facet response and a sold-inventory experiment establish

--- a/docs/visor-api-migration.md
+++ b/docs/visor-api-migration.md
@@ -220,6 +220,14 @@ adapted listings to the existing `output/raw` envelope, and passes those listing
 the legacy Level 2 analysis and report pipeline. Level 1 remains on its separate
 facet-native path.
 
+Level 2 retains every returned listing in the report. Listings with compatible KBB
+pricing and a saved vehicle-history report receive the complete risk-adjusted
+rating. Listings with KBB pricing but no report receive a clearly separated price
+assessment; risk and the final Level 2 rating remain unavailable. Listings without
+usable pricing or a KBB mapping appear in an information-only section with the
+specific reason. Unfavorable complete ratings are displayed rather than reduced to
+summary counts.
+
 An end-to-end live test on 2026-07-21 collected 10 used 2024 Subaru Foresters,
 retrieved all 10 detail records, discovered three dealer history-report links,
 completed KBB matching, parsed three saved CARFAX reports, and generated the Level 2

--- a/docs/visor-api-migration.md
+++ b/docs/visor-api-migration.md
@@ -215,8 +215,16 @@ duplicate IDs are retained as structured exclusions rather than disappearing.
 `visor_api.level2_cache.cached_level2_collection` stores the complete collection,
 including raw search/detail records and exclusions, in an atomic local daily cache.
 It supports forced refresh and invalidates corrupt, stale, or incompatible cache
-envelopes. This service is the Level 2 acquisition boundary only; routing the
-`--level2` CLI workflow through it remains a later integration task in issue #238.
+envelopes. The `--level2` CLI workflow now routes through this service, writes the
+adapted listings to the existing `output/raw` envelope, and passes those listings to
+the legacy Level 2 analysis and report pipeline. Level 1 remains on its separate
+facet-native path.
+
+An end-to-end live test on 2026-07-21 collected 10 used 2024 Subaru Foresters,
+retrieved all 10 detail records, discovered three dealer history-report links,
+completed KBB matching, parsed three saved CARFAX reports, and generated the Level 2
+PDF. The test also established that API-null document URLs must use the same URL
+validity check as legacy `"Unavailable"` sentinels.
 
 ## Market-overview source determination
 

--- a/templates/level2.css
+++ b/templates/level2.css
@@ -14,18 +14,21 @@ h2 { margin: 13px 0 6px; color: #163a5f; font-size: 11pt; break-after: avoid; }
 
 .intro { margin: 8px 0 6px; color: #52606d; }
 .intro p { margin: 3px 0; }
+.rating-guide { margin: 6px 0; padding: 5px 7px; border-left: 3px solid #40729f; background: #f2f6f9; color: #31465a; font-size: 7.5pt; }
 .generated, .footnote { color: #607080; font-size: 7pt; }
 .generated { font-style: italic; }
 .report-counts { margin: 7px 0 10px; }
 
 .deal-bin { margin: 0; }
-.listing { margin: 0 0 12px; padding: 7px 9px 8px 12px; border-left: 7px solid; border-radius: 3px; break-inside: avoid; page-break-inside: avoid; }
-.great-listing { --accent-color: #2f855a; border-color: var(--accent-color); background: #edf7f1; }
-.good-listing { --accent-color: #4d8fb8; border-color: var(--accent-color); background: #eef6fa; }
-.fair-listing { --accent-color: #c5a12f; border-color: var(--accent-color); background: #fbf8e9; }
-.poor-listing { --accent-color: #d47736; border-color: var(--accent-color); background: #fcf2eb; }
-.bad-listing { --accent-color: #c2413b; border-color: var(--accent-color); background: #fbeeee; }
-.suspicious-listing { --accent-color: #7a8793; border-color: var(--accent-color); background: #f1f3f5; }
+.listing { position: relative; margin: 0 0 12px; padding: 7px 9px 8px 12px; border-left: 7px solid #dbe3ea; border-radius: 3px; break-inside: avoid; page-break-inside: avoid; }
+.deal-strength-track { position: absolute; top: 0; bottom: 0; left: -7px; width: 7px; overflow: hidden; background: #dbe3ea; border-radius: 3px 0 0 3px; }
+.deal-strength-track span { position: absolute; right: 0; bottom: 0; left: 0; background: var(--accent-color); }
+.great-listing { --accent-color: #2f855a; background: #edf7f1; }
+.good-listing { --accent-color: #4d8fb8; background: #eef6fa; }
+.fair-listing { --accent-color: #c5a12f; background: #fbf8e9; }
+.poor-listing { --accent-color: #d47736; background: #fcf2eb; }
+.bad-listing { --accent-color: #c2413b; background: #fbeeee; }
+.suspicious-listing { --accent-color: #7a8793; background: #f1f3f5; }
 
 .image-viewer { display: flex; align-items: center; gap: 6px; width: 100%; height: 105px; margin-bottom: 4px; overflow: hidden; }
 .image-viewer img { width: calc((100% - 12px) / 3); height: 105px; object-fit: contain; border-radius: 3px; background: #eef2f5; }
@@ -42,14 +45,10 @@ h2 { margin: 13px 0 6px; color: #163a5f; font-size: 11pt; break-after: avoid; }
 .price-position { margin: 5px 0 12px; font-size: 7pt; }
 .price-track { position: relative; height: 15px; overflow: visible; border-radius: 2px; background: #dbe3ea; }
 .price-segment { position: absolute; top: 0; height: 15px; overflow: hidden; color: #fff; font-size: 5.8pt; font-weight: 650; line-height: 15px; text-align: center; }
-.price-segment.great { left: 0; background: #2f855a; border-radius: 2px 0 0 2px; }
-.price-segment.good { background: #4d8fb8; }
-.price-segment.fair { color: #3d3208; background: #d9bd4a; }
-.price-segment.poor { background: #d47736; }
-.price-segment.bad { background: #c2413b; border-radius: 0 2px 2px 0; }
-.listing-marker { position: absolute; top: -5px; z-index: 2; transform: translateX(-50%); }
-.listing-marker::before { content: ""; position: absolute; top: -3px; left: 50%; width: 0; height: 0; border-left: 5px solid transparent; border-right: 5px solid transparent; border-top: 6px solid #101820; transform: translateX(-50%); }
-.listing-marker span { display: block; width: 5px; height: 25px; background: #101820; border: 1px solid #fff; border-radius: 2px; box-shadow: 0 0 0 1px #101820; }
+.price-segment.great { left: 0; border-radius: 2px 0 0 2px; }
+.price-segment.fair { color: #3d3208; }
+.price-segment.bad { border-radius: 0 2px 2px 0; }
+.listing-marker { position: absolute; top: -3px; z-index: 2; width: 0; height: 0; border-left: 7px solid transparent; border-right: 7px solid transparent; border-top: 21px solid #fff; filter: drop-shadow(0 0 1px #18212b); transform: translateX(-50%); }
 .price-cutoffs { position: relative; height: 10px; color: #52606d; font-size: 5.8pt; }
 .price-cutoffs span { position: absolute; top: 1px; transform: translateX(-50%); white-space: nowrap; }
 

--- a/templates/level2.css
+++ b/templates/level2.css
@@ -26,7 +26,6 @@ h2 { margin: 13px 0 6px; color: #163a5f; font-size: 11pt; break-after: avoid; }
 .fair-listing { --accent-color: #c5a12f; background: #fbf8e9; }
 .poor-listing { --accent-color: #d47736; background: #fcf2eb; }
 .bad-listing { --accent-color: #c2413b; background: #fbeeee; }
-.suspicious-listing { --accent-color: #7a8793; background: #f1f3f5; }
 
 .listing-layout.has-images { display: grid; grid-template-columns: 126px minmax(0, 1fr); gap: 9px; align-items: start; }
 .listing-content { min-width: 0; }

--- a/templates/level2.css
+++ b/templates/level2.css
@@ -24,7 +24,8 @@ h2 { margin: 13px 0 6px; color: #163a5f; font-size: 11pt; break-after: avoid; }
 .good-listing { --accent-color: #4d8fb8; border-color: var(--accent-color); background: #eef6fa; }
 .fair-listing { --accent-color: #c5a12f; border-color: var(--accent-color); background: #fbf8e9; }
 .poor-listing { --accent-color: #d47736; border-color: var(--accent-color); background: #fcf2eb; }
-.bad-listing, .suspicious-listing { --accent-color: #c2413b; border-color: var(--accent-color); background: #fbeeee; }
+.bad-listing { --accent-color: #c2413b; border-color: var(--accent-color); background: #fbeeee; }
+.suspicious-listing { --accent-color: #7a8793; border-color: var(--accent-color); background: #f1f3f5; }
 
 .image-viewer { display: flex; align-items: center; gap: 6px; width: 100%; height: 105px; margin-bottom: 4px; overflow: hidden; }
 .image-viewer img { width: calc((100% - 12px) / 3); height: 105px; object-fit: contain; border-radius: 3px; background: #eef2f5; }

--- a/templates/level2.css
+++ b/templates/level2.css
@@ -1,276 +1,67 @@
-@page {
-	margin: 0.8in;
-}
+@page { size: A4; margin: 12mm; }
+* { box-sizing: border-box; }
+html, body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+body { margin: 0; color: #18212b; background: #fff; font: 9pt/1.35 "Segoe UI", Arial, sans-serif; }
 
-html,
-body {
-	-webkit-print-color-adjust: exact;
-	print-color-adjust: exact;
-}
-body {
-	font-family: "Segoe UI", Helvetica, Arial, sans-serif;
-	font-size: 11pt;
-	line-height: 1.5;
-	color: #1e1e1e;
-	background-color: #fff;
-	margin: 0;
-	/* border-bottom: 2px solid #e5e5e5; */
-}
-body h1 {
-	font-size: 20pt;
-	font-weight: 600;
-	margin-bottom: 0.6em;
-	border-bottom: 2px solid #e5e5e5;
-	padding-bottom: 0.3em;
-}
+header { border-bottom: 2px solid #163a5f; padding-bottom: 8px; break-inside: avoid; break-after: avoid; }
+.title-row { display: flex; align-items: center; justify-content: space-between; gap: 18px; }
+.title-row img { width: 135px; height: 40px; object-fit: contain; object-position: right center; }
+.report-title { min-width: 0; }
+.eyebrow { margin: 0 0 2px; color: #40729f; font-size: 8pt; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; }
+h1 { margin: 0; font-size: 21pt; font-weight: 650; }
+h2 { margin: 13px 0 6px; color: #163a5f; font-size: 11pt; break-after: avoid; }
+.scope { margin: 4px 0 0; color: #52606d; }
 
-.footnote {
-	font-size: 9pt;
-	font-style: italic;
-	color: #666;
-	margin-top: -0.5em;
-	margin-bottom: 1em;
-	font-weight: 400;
-	border-left: 0;
-	padding-left: 0;
-}
+.intro { margin: 8px 0 6px; color: #52606d; }
+.intro p { margin: 3px 0; }
+.generated, .footnote { color: #607080; font-size: 7pt; }
+.generated { font-style: italic; }
+.report-counts { margin: 7px 0 10px; }
 
-.deal-bin {
-	list-style-type: none;
-	padding-left: 0;
-	margin-bottom: 1em;
-	margin-right: 4px;
-}
-.break-before {
-	break-before: page;
-	page-break-before: always;
-}
+.deal-bin { margin: 0; }
+.listing { margin: 0 0 12px; padding: 7px 9px 8px 12px; border-left: 7px solid; border-radius: 3px; break-inside: avoid; page-break-inside: avoid; }
+.great-listing { --accent-color: #2f855a; border-color: var(--accent-color); background: #edf7f1; }
+.good-listing { --accent-color: #4d8fb8; border-color: var(--accent-color); background: #eef6fa; }
+.fair-listing { --accent-color: #c5a12f; border-color: var(--accent-color); background: #fbf8e9; }
+.poor-listing { --accent-color: #d47736; border-color: var(--accent-color); background: #fcf2eb; }
+.bad-listing, .suspicious-listing { --accent-color: #c2413b; border-color: var(--accent-color); background: #fbeeee; }
 
-.filtered-out {
-	margin-top: 20px;
-	page-break-inside: avoid;
-	break-inside: avoid;
-	border-bottom: 2px solid #e5e5e5;
-	padding-bottom: 2em;
-}
-.filtered-out h3 {
-	margin-top: 0 !important;
-	font-size: 14pt;
-	font-weight: 600;
-	margin-bottom: 0.6em;
-	color: #333;
-	page-break-after: avoid;
-	break-after: avoid-page;
-}
-.no-break {
-	page-break-inside: avoid;
-	break-inside: avoid;
-	display: inline-block; /* this is what forces Chromium to keep it intact */
-	width: 100%;
-}
+.image-viewer { display: flex; align-items: center; gap: 6px; width: 100%; height: 105px; margin-bottom: 4px; overflow: hidden; }
+.image-viewer img { width: calc((100% - 12px) / 3); height: 105px; object-fit: contain; border-radius: 3px; background: #eef2f5; }
+.listing-title { position: relative; padding-right: 105px; color: #18212b; font-size: 11pt; font-weight: 650; }
+.listing-title-bar { width: 100%; height: 2px; margin: 2px 0 4px; background: var(--accent-color); opacity: .55; }
+.visor-link { position: absolute; right: 0; color: #1769aa; font-size: 7.5pt; font-weight: 500; text-decoration: underline; }
+.downgrade-tag { display: inline-block; margin-left: 5px; padding: 1px 5px; color: #8b2020; background: #f8d7d7; border-radius: 3px; font-size: 7pt; }
+.deal-rating { display: inline-block; margin-left: 6px; padding: 1px 7px; color: #fff; background: var(--accent-color); border-radius: 9px; font-size: 7pt; font-weight: 700; vertical-align: 1px; }
 
-.section-label {
-	text-transform: uppercase;
-	font-size: 1rem;
-	color: #555;
-	letter-spacing: 0.05em;
-	margin-bottom: 0.3rem;
-	margin-top: 0.3rem;
-}
-.intro {
-	margin: 1rem 0 1.5rem;
-	padding: 0.6rem 1rem;
-	border-left: 3px solid #999999; /* subtle neutral accent */
-	border-radius: 0;
-	border-top: 0;
-	border-right: 0;
-	border-bottom: 0;
-	background: none;
-}
-.intro p {
-	margin: 0.4rem 0;
-	line-height: 1.5;
-}
-.criteria strong {
-	color: #333;
-}
+.compact-grid { display: grid; grid-template-columns: 1fr 1fr; column-gap: 12px; row-gap: 1px; font-size: 8pt; }
+.compact-grid div { min-width: 0; overflow-wrap: anywhere; }
+.dealer-link { color: #1769aa; font-weight: 600; text-decoration: underline; }
 
-.section-header {
-	font-size: 20px;
-	font-weight: 600;
-	margin-top: 28px;
-	margin-bottom: 12px;
-}
+.price-position { margin: 5px 0 12px; font-size: 7pt; }
+.price-track { position: relative; height: 15px; overflow: visible; border-radius: 2px; background: #dbe3ea; }
+.price-segment { position: absolute; top: 0; height: 15px; overflow: hidden; color: #fff; font-size: 5.8pt; font-weight: 650; line-height: 15px; text-align: center; }
+.price-segment.great { left: 0; background: #2f855a; border-radius: 2px 0 0 2px; }
+.price-segment.good { background: #4d8fb8; }
+.price-segment.fair { color: #3d3208; background: #d9bd4a; }
+.price-segment.poor { background: #d47736; }
+.price-segment.bad { background: #c2413b; border-radius: 0 2px 2px 0; }
+.listing-marker { position: absolute; top: -5px; z-index: 2; transform: translateX(-50%); }
+.listing-marker::before { content: ""; position: absolute; top: -3px; left: 50%; width: 0; height: 0; border-left: 5px solid transparent; border-right: 5px solid transparent; border-top: 6px solid #101820; transform: translateX(-50%); }
+.listing-marker span { display: block; width: 5px; height: 25px; background: #101820; border: 1px solid #fff; border-radius: 2px; box-shadow: 0 0 0 1px #101820; }
+.price-cutoffs { position: relative; height: 10px; color: #52606d; font-size: 5.8pt; }
+.price-cutoffs span { position: absolute; top: 1px; transform: translateX(-50%); white-space: nowrap; }
 
-/* Entire listing container */
-.listing {
-	padding: 0.6rem 1rem 0.8rem 1.4rem;
-	border-radius: 4px;
-	page-break-inside: avoid;
-	margin-bottom: 20px;
-	box-sizing: border-box;
-}
+.listing-notes { font-size: 7.5pt; }
+.listing-notes ul { margin: 2px 0 0; padding-left: 14px; }
+.listing-notes li { margin-bottom: 1px; }
 
-/* Fair */
-.fair-listing {
-	--accent-color: #f1c40f;
-	border-left: 6px solid var(--accent-color);
-	background: #f1c40f15;
-}
+.unable-summary { break-before: page; }
+.unable-summary p { margin: 0 0 4px; color: #586775; }
+.unable-summary ul { margin: 0; padding-left: 16px; }
+.unable-summary li { margin-bottom: 3px; }
 
-/* Good */
-.good-listing {
-	--accent-color: #3498db;
-	border-left: 6px solid var(--accent-color);
-	background: #3498db15;
-}
-
-/* Great */
-.great-listing {
-	--accent-color: #2ecc71;
-	border-left: 6px solid var(--accent-color);
-	background: #2ecc7115;
-}
-
-.poor-listing {
-	--accent-color: #e67e22;
-	border-left: 6px solid var(--accent-color);
-	background: #e67e2215;
-}
-
-.bad-listing,
-.suspicious-listing {
-	--accent-color: #c0392b;
-	border-left: 6px solid var(--accent-color);
-	background: #c0392b12;
-}
-
-.pending-listing {
-	--accent-color: #7f8c8d;
-	border-left: 6px solid var(--accent-color);
-	background: #7f8c8d12;
-}
-
-.unavailable-listing {
-	--accent-color: #777;
-	border-left: 6px solid var(--accent-color);
-	background: #7777770d;
-}
-
-/* Title */
-.listing-title {
-	font-size: 12pt;
-	font-weight: 600;
-	margin-bottom: 0.3rem;
-	color: #222;
-	position: relative;
-}
-
-.visor-link {
-	color: var(--accent-color);
-	/* font-weight: lighter; */
-	font-size: smaller;
-	text-decoration: none;
-	/* float: right; */
-	position: absolute;
-	right: 20%;
-}
-
-.downgrade-tag {
-	display: inline-block;
-	background: #ffcccc;
-	color: #a00;
-	font-size: 8.5pt;
-	font-weight: 600;
-	padding: 1px 6px;
-	border-radius: 4px;
-	margin-left: 6px;
-	vertical-align: middle;
-}
-
-/* Title bar under the listing title */
-.listing-title-bar {
-	width: 80%;
-	height: 3px;
-	margin-bottom: 0.3rem;
-	background: var(--accent-color); /* Color matching for each deal rating */
-	opacity: 0.35;
-}
-
-.listing-specs {
-	margin-bottom: 0.3rem;
-}
-
-.compact-grid {
-	display: grid;
-	/* grid-template-columns: repeat(2, 1fr); */
-	grid-template-columns: calc(50% - 0.4rem) calc(50% - 0.4rem);
-	column-gap: 0.8rem;
-	row-gap: 0.15rem;
-	font-size: 9.5pt;
-}
-
-.listing-specs-item {
-	margin-bottom: 0.1rem;
-	overflow-wrap: break-word;
-}
-
-.listing-specs strong {
-	white-space: normal;
-}
-
-.dealer-link {
-	color: var(--accent-color);
-	text-decoration: none;
-	font-weight: 600;
-}
-
-/* Notes block */
-.listing-notes {
-	font-size: 9.5pt;
-}
-
-.listing-notes ul {
-	list-style-type: disc !important;
-	list-style-position: outside !important;
-	margin-left: 1rem !important;
-	padding-left: 0.5rem !important;
-}
-
-.note-line {
-	margin-bottom: 2px;
-	line-height: 0.9rem;
-}
-
-.methodology {
-	background: #f7f7f7;
-	padding: 10px 20px;
-	border-radius: 4px;
-}
-
-.methodology h2 {
-	padding: 0;
-}
-
-.methodology ul {
-	padding-left: 20px;
-	margin-left: 0;
-	list-style-type: disc;
-}
-
-/* ========== TESTING ========== */
-.image-viewer {
-	display: flex;
-	flex-direction: row;
-	gap: 6px; /* optional spacing */
-	width: 100%;
-	padding-bottom: 4px;
-}
-
-.image-viewer img {
-	flex: 1; /* each image takes equal width */
-	max-width: 33%; /* safety cap */
-	height: auto;
-	border-radius: 4px;
-	object-fit: cover;
-}
+footer { margin-top: 12px; padding-top: 7px; border-top: 1px solid #aebdca; color: #586775; font-size: 7pt; }
+footer h2 { margin-top: 0; }
+footer ul { margin: 4px 0; padding-left: 16px; }
+footer li { margin-bottom: 3px; }

--- a/templates/level2.css
+++ b/templates/level2.css
@@ -20,9 +20,10 @@ h2 { margin: 13px 0 6px; color: #163a5f; font-size: 11pt; break-after: avoid; }
 .report-counts { margin: 7px 0 10px; }
 
 .deal-bin { margin: 0; }
-.listing { position: relative; margin: 0 0 12px; padding: 7px 9px 8px 12px; border-left: 7px solid #dbe3ea; border-radius: 3px; break-inside: avoid; page-break-inside: avoid; }
-.deal-strength-track { position: absolute; top: 0; bottom: 0; left: -7px; width: 7px; overflow: hidden; background: #dbe3ea; border-radius: 3px 0 0 3px; }
-.deal-strength-track span { position: absolute; right: 0; bottom: 0; left: 0; background: var(--accent-color); }
+.listing { position: relative; margin: 0 0 12px; padding: 7px 9px 8px 12px; border-left: 7px solid var(--accent-color); border-radius: 3px; break-inside: avoid; page-break-inside: avoid; }
+.deal-strength-track { position: absolute; top: 0; bottom: 0; left: -7px; width: 7px; overflow: visible; background: var(--accent-color); border-radius: 3px 0 0 3px; }
+.deal-strength-marker { position: absolute; right: -5px; width: 12px; height: 3px; border-top: 2px solid #fff; filter: drop-shadow(0 0 1px #18212b); transform: translateY(50%); }
+.deal-strength-marker b { position: absolute; top: -7px; left: 13px; min-width: 27px; padding: 1px 3px; color: #fff; background: var(--accent-color); border: 1px solid #fff; border-radius: 5px; font-size: 5.5pt; line-height: 9px; text-align: center; white-space: nowrap; }
 .great-listing { --accent-color: #2f855a; background: #edf7f1; }
 .good-listing { --accent-color: #4d8fb8; background: #eef6fa; }
 .fair-listing { --accent-color: #c5a12f; background: #fbf8e9; }

--- a/templates/level2.css
+++ b/templates/level2.css
@@ -37,6 +37,7 @@ h2 { margin: 13px 0 6px; color: #163a5f; font-size: 11pt; break-after: avoid; }
 .visor-link { position: absolute; right: 0; color: #1769aa; font-size: 7.5pt; font-weight: 500; text-decoration: underline; }
 .downgrade-tag { display: inline-block; margin-left: 5px; padding: 1px 5px; color: #8b2020; background: #f8d7d7; border-radius: 3px; font-size: 7pt; }
 .deal-rating { display: inline-block; margin-left: 6px; padding: 1px 7px; color: #fff; background: var(--accent-color); border-radius: 9px; font-size: 7pt; font-weight: 700; vertical-align: 1px; }
+.condition-badge { display: inline-block; margin-left: 6px; padding: 1px 6px; color: #40576b; background: #fff; border: 1px solid #9badbc; border-radius: 9px; font-size: 6.5pt; font-weight: 700; text-transform: uppercase; vertical-align: 1px; }
 
 .compact-grid { display: grid; grid-template-columns: 1fr 1fr; column-gap: 12px; row-gap: 1px; font-size: 8pt; }
 .compact-grid div { min-width: 0; overflow-wrap: anywhere; }

--- a/templates/level2.css
+++ b/templates/level2.css
@@ -21,11 +21,6 @@ h2 { margin: 13px 0 6px; color: #163a5f; font-size: 11pt; break-after: avoid; }
 
 .deal-bin { margin: 0; }
 .listing { position: relative; margin: 0 0 12px; padding: 7px 9px 8px 12px; border-left: 7px solid var(--accent-color); border-radius: 3px; break-inside: avoid; page-break-inside: avoid; }
-.deal-strength-track { position: absolute; top: 0; bottom: 0; left: -7px; width: 7px; overflow: visible; background: var(--accent-color); border-radius: 3px 0 0 3px; }
-.deal-strength-marker { position: absolute; right: -5px; width: 12px; height: 3px; border-top: 2px solid #fff; filter: drop-shadow(0 0 1px #18212b); transform: translateY(50%); }
-.deal-strength-marker b { position: absolute; top: -7px; right: 13px; min-width: 27px; padding: 1px 3px; color: #fff; background: var(--accent-color); border: 1px solid #fff; border-radius: 5px; font-size: 5.5pt; line-height: 9px; text-align: center; white-space: nowrap; }
-.deal-strength-marker.marker-high b { top: 0; }
-.deal-strength-marker.marker-low b { top: -14px; }
 .great-listing { --accent-color: #2f855a; background: #edf7f1; }
 .good-listing { --accent-color: #4d8fb8; background: #eef6fa; }
 .fair-listing { --accent-color: #c5a12f; background: #fbf8e9; }
@@ -38,7 +33,7 @@ h2 { margin: 13px 0 6px; color: #163a5f; font-size: 11pt; break-after: avoid; }
 .image-viewer { display: flex; flex-direction: column; gap: 5px; width: 126px; overflow: hidden; }
 .image-viewer img { width: 126px; height: 82px; object-fit: contain; border-radius: 3px; background: #eef2f5; }
 .listing-title { position: relative; padding-right: 105px; color: #18212b; font-size: 11pt; font-weight: 650; }
-.listing-title-bar { width: 100%; height: 2px; margin: 2px 0 4px; background: var(--accent-color); opacity: .55; }
+.listing-title-bar { width: 100%; height: 2px; margin: 5px 0 4px; background: var(--accent-color); opacity: .55; }
 .visor-link { position: absolute; right: 0; color: #1769aa; font-size: 7.5pt; font-weight: 500; text-decoration: underline; }
 .downgrade-tag { display: inline-block; margin-left: 5px; padding: 1px 5px; color: #8b2020; background: #f8d7d7; border-radius: 3px; font-size: 7pt; }
 .deal-rating { display: inline-block; margin-left: 6px; padding: 1px 7px; color: #fff; background: var(--accent-color); border-radius: 9px; font-size: 7pt; font-weight: 700; vertical-align: 1px; }
@@ -46,8 +41,13 @@ h2 { margin: 13px 0 6px; color: #163a5f; font-size: 11pt; break-after: avoid; }
 .compact-grid { display: grid; grid-template-columns: 1fr 1fr; column-gap: 12px; row-gap: 1px; font-size: 8pt; }
 .compact-grid div { min-width: 0; overflow-wrap: anywhere; }
 .dealer-link { color: #1769aa; font-weight: 600; text-decoration: underline; }
+.listing-evaluation.has-score { display: grid; grid-template-columns: minmax(0, 1fr) 82px; gap: 9px; align-items: stretch; }
+.listing-measures { min-width: 0; }
+.deal-score { display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 60px; padding: 2px 8px; color: var(--accent-color); background: rgba(255, 255, 255, .72); border: 2px solid var(--accent-color); border-radius: 5px; text-align: center; }
+.deal-score strong { font-size: 7pt; }
+.deal-score span { color: #18212b; font-size: 23pt; font-weight: 650; line-height: 1.05; }
 
-.price-position { margin: 5px 0 12px; font-size: 7pt; }
+.price-position { margin: 9px 0 12px; font-size: 7pt; }
 .price-track { position: relative; height: 15px; overflow: visible; border-radius: 2px; background: #dbe3ea; }
 .price-segment { position: absolute; top: 0; height: 15px; overflow: hidden; color: #fff; font-size: 5.8pt; font-weight: 650; line-height: 15px; text-align: center; }
 .price-segment.great { left: 0; border-radius: 2px 0 0 2px; }

--- a/templates/level2.css
+++ b/templates/level2.css
@@ -132,6 +132,31 @@ body h1 {
 	background: #2ecc7115;
 }
 
+.poor-listing {
+	--accent-color: #e67e22;
+	border-left: 6px solid var(--accent-color);
+	background: #e67e2215;
+}
+
+.bad-listing,
+.suspicious-listing {
+	--accent-color: #c0392b;
+	border-left: 6px solid var(--accent-color);
+	background: #c0392b12;
+}
+
+.pending-listing {
+	--accent-color: #7f8c8d;
+	border-left: 6px solid var(--accent-color);
+	background: #7f8c8d12;
+}
+
+.unavailable-listing {
+	--accent-color: #777;
+	border-left: 6px solid var(--accent-color);
+	background: #7777770d;
+}
+
 /* Title */
 .listing-title {
 	font-size: 12pt;

--- a/templates/level2.css
+++ b/templates/level2.css
@@ -23,7 +23,9 @@ h2 { margin: 13px 0 6px; color: #163a5f; font-size: 11pt; break-after: avoid; }
 .listing { position: relative; margin: 0 0 12px; padding: 7px 9px 8px 12px; border-left: 7px solid var(--accent-color); border-radius: 3px; break-inside: avoid; page-break-inside: avoid; }
 .deal-strength-track { position: absolute; top: 0; bottom: 0; left: -7px; width: 7px; overflow: visible; background: var(--accent-color); border-radius: 3px 0 0 3px; }
 .deal-strength-marker { position: absolute; right: -5px; width: 12px; height: 3px; border-top: 2px solid #fff; filter: drop-shadow(0 0 1px #18212b); transform: translateY(50%); }
-.deal-strength-marker b { position: absolute; top: -7px; left: 13px; min-width: 27px; padding: 1px 3px; color: #fff; background: var(--accent-color); border: 1px solid #fff; border-radius: 5px; font-size: 5.5pt; line-height: 9px; text-align: center; white-space: nowrap; }
+.deal-strength-marker b { position: absolute; top: -7px; right: 13px; min-width: 27px; padding: 1px 3px; color: #fff; background: var(--accent-color); border: 1px solid #fff; border-radius: 5px; font-size: 5.5pt; line-height: 9px; text-align: center; white-space: nowrap; }
+.deal-strength-marker.marker-high b { top: 0; }
+.deal-strength-marker.marker-low b { top: -14px; }
 .great-listing { --accent-color: #2f855a; background: #edf7f1; }
 .good-listing { --accent-color: #4d8fb8; background: #eef6fa; }
 .fair-listing { --accent-color: #c5a12f; background: #fbf8e9; }
@@ -31,8 +33,10 @@ h2 { margin: 13px 0 6px; color: #163a5f; font-size: 11pt; break-after: avoid; }
 .bad-listing { --accent-color: #c2413b; background: #fbeeee; }
 .suspicious-listing { --accent-color: #7a8793; background: #f1f3f5; }
 
-.image-viewer { display: flex; align-items: center; gap: 6px; width: 100%; height: 105px; margin-bottom: 4px; overflow: hidden; }
-.image-viewer img { width: calc((100% - 12px) / 3); height: 105px; object-fit: contain; border-radius: 3px; background: #eef2f5; }
+.listing-layout.has-images { display: grid; grid-template-columns: 126px minmax(0, 1fr); gap: 9px; align-items: start; }
+.listing-content { min-width: 0; }
+.image-viewer { display: flex; flex-direction: column; gap: 5px; width: 126px; overflow: hidden; }
+.image-viewer img { width: 126px; height: 82px; object-fit: contain; border-radius: 3px; background: #eef2f5; }
 .listing-title { position: relative; padding-right: 105px; color: #18212b; font-size: 11pt; font-weight: 650; }
 .listing-title-bar { width: 100%; height: 2px; margin: 2px 0 4px; background: var(--accent-color); opacity: .55; }
 .visor-link { position: absolute; right: 0; color: #1769aa; font-size: 7.5pt; font-weight: 500; text-decoration: underline; }

--- a/templates/level2.html
+++ b/templates/level2.html
@@ -40,7 +40,9 @@
 			{% set vin = listing.vin %}
 			{% set imgs = all_images.get(vin, []) %}
 
+			<div class="listing-layout{% if imgs %} has-images{% endif %}">
 			{% if imgs %}<div class="image-viewer">{% for img in imgs %}<img src="{{ img }}" alt="Vehicle image">{% endfor %}</div>{% endif %}
+			<div class="listing-content">
 			<div class="listing-title">
 				{{ listing.title }}
 				<span class="deal-rating">{{ deal }}</span>
@@ -73,10 +75,12 @@
 				</div>
 			</div>
 			<div class="listing-notes"><strong>Notes:</strong><ul>{% for line in narrative %}<li>{{ line }}</li>{% endfor %}</ul></div>
+			</div>
+			</div>
 		{%- endmacro %}
 
 		<main class="deal-bin">
-			{% for rating in all_ratings %}<article class="listing {{ rating[1]|lower }}-listing"><div class="deal-strength-track">{% if rating[4].deal_strength is not none %}<span class="deal-strength-marker" data-bottom-pct="{{ rating[4].deal_strength }}"><b>{{ rating[4].deal_strength|round|int }}%</b></span>{% endif %}</div>{{ vehicle_row(rating) }}</article>{% endfor %}
+			{% for rating in all_ratings %}<article class="listing {{ rating[1]|lower }}-listing"><div class="deal-strength-track">{% if rating[4].deal_strength is not none %}<span class="deal-strength-marker{% if rating[4].deal_strength >= 90 %} marker-high{% elif rating[4].deal_strength <= 10 %} marker-low{% endif %}" data-bottom-pct="{{ rating[4].deal_strength }}"><b>{{ rating[4].deal_strength|round|int }}%</b></span>{% endif %}</div>{{ vehicle_row(rating) }}</article>{% endfor %}
 		</main>
 
 		{% if information_summary %}

--- a/templates/level2.html
+++ b/templates/level2.html
@@ -45,6 +45,7 @@
 			<div class="listing-content">
 			<div class="listing-title">
 				{{ listing.title }}
+				<span class="condition-badge">{{ display_listing_condition(listing.get("condition")) }}</span>
 				<span class="deal-rating">{{ deal }}</span>
 				{% if is_downgraded %}<span class="downgrade-tag">Downgraded</span>{% endif %}
 				<a class="visor-link" href="{{ listing.visor_listing }}">View on Visor</a>

--- a/templates/level2.html
+++ b/templates/level2.html
@@ -19,7 +19,7 @@
 		<section class="intro">
 			<p class="generated">Generated: {{ generated_at }}</p>
 			<p>This report compares each listing with compatible KBB pricing. When a vehicle-history report is available, it also evaluates title, accident, mileage, service, and warranty evidence to produce a complete rating.</p>
-			<div class="rating-guide"><strong>Reading each rating:</strong> The white triangle shows the evidence-adjusted price position across the colored deal scale; the prices below it are rating cutoffs. Deal Score uses that entire scale, from 100% at the strongest end to 0% at the weakest. It is not a confidence score.</div>
+			<div class="rating-guide"><strong>Reading each rating:</strong> The white triangle shows the listing price across the colored price scale; the prices below it are rating cutoffs. Deal Score starts with that full 0–100 price scale, subtracts an accelerating penalty for actual risk, and adds modest low-mileage and warranty bonuses. It is not a confidence score.</div>
 			<p class="footnote">A complete Level 2 rating requires both compatible KBB pricing and a vehicle-history report. Listings without that evidence receive a price assessment or are counted under an evaluation failure reason.</p>
 		</section>
 
@@ -101,6 +101,7 @@
 			<ul>
 				<li>Price is compared with local KBB Fair Purchase Price, then national FPP or Fair Market Value when needed.</li>
 				<li>A complete rating requires a vehicle-history report. Title, accident, odometer, mileage, service, and warranty evidence can improve or worsen the price-based rating.</li>
+				<li>Risk has an accelerating effect: small risks have limited impact, while moderate and high risks reduce Deal Score increasingly sharply.</li>
 				<li>Listings without a history report, price, or compatible KBB data are summarized by reason rather than displayed individually.</li>
 				<li>CARFAX warranty status is an estimate and should be confirmed with the manufacturer or dealer.</li>
 			</ul>

--- a/templates/level2.html
+++ b/templates/level2.html
@@ -1,269 +1,99 @@
 <!doctype html>
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
+		<meta charset="utf-8">
 		<title>Level 2 Analysis Report - {{ make }} {{ model }}</title>
 	</head>
 	<body>
-		<h1>{{ report_title }}</h1>
-		<h3 class="footnote">Generated: {{ generated_at }}</h3>
+		<header>
+			<div class="title-row">
+				<div class="report-title">
+					<p class="eyebrow">Level 2</p>
+					<h1>{{ make }} {{ model }} Market Overview</h1>
+				</div>
+				{% if logo %}<img src="{{ logo }}" alt="DealLens">{% endif %}
+			</div>
+			<p class="scope">{{ summary }}</p>
+		</header>
+
 		<section class="intro">
-			<p class="criteria">{{ summary }}</p>
-			<p class="overview">
-				Building on Level 1 findings, this Level 2 report incorporates verified
-				vehicle history data to evaluate warranty coverage, accident severity,
-				title status, and other long-term risk factors influencing fair value.
-			</p>
-			<p class="footnote">
-				A complete Level 2 rating requires both compatible KBB pricing and a
-				vehicle-history report. Listings without that evidence remain visible
-				below as price assessments or information-only listings.
-			</p>
+			<p class="generated">Generated: {{ generated_at }}</p>
+			<p>This report compares each listing with compatible KBB pricing. When a vehicle-history report is available, it also evaluates title, accident, mileage, service, and warranty evidence to produce a complete rating.</p>
+			<p class="footnote">A complete Level 2 rating requires both compatible KBB pricing and a vehicle-history report. Listings without that evidence receive a price assessment or are counted under an evaluation failure reason.</p>
 		</section>
 
-		Of {{ total_count }} returned listings, <strong>{{ full_count }}</strong>
-		received a complete risk-adjusted Level 2 rating,
-		<strong>{{ price_only|length }}</strong> received a price assessment while
-		awaiting a history report, and <strong>{{ information_only|length }}</strong>
-		could not be evaluated. <strong>Every returned listing is shown.</strong>
+		<p class="report-counts">Of {{ total_count }} returned listings, <strong>{{ full_count }}</strong> received a complete risk-adjusted Level 2 rating. The remaining <strong>{{ total_count - full_count }}</strong> could not be fully evaluated and are summarized by reason below.</p>
+
 		{% macro miles(n) -%}{{ "{:,}".format(n) }}{%- endmacro %}
 		{% macro money(n) -%}{{ "${:,.0f}".format(n) }}{%- endmacro %}
-
 		{% macro vehicle_row(rating) -%}
-			<!-- 0: listing, 1: deal, 2: risk, 3: narrative -->
 			{% set listing = rating[0] %}
 			{% set deal = rating[1] %}
 			{% set risk = rating[2] %}
 			{% set narrative = rating[3] %}
+			{% set pricing = rating[4] %}
 			{% set last_line = narrative[-1] %}
 			{% set is_downgraded = "downgraded" in last_line.lower() %}
 			{% set seller_name = listing.seller.name if listing.seller.name else "N/A" %}
-			{% set seller_location = listing.seller.location if listing.seller.location else "N/A" %}
+			{% set seller_location = display_dealer_location(listing.seller.location) %}
 			{% set vin = listing.vin %}
 			{% set imgs = all_images.get(vin, []) %}
 
-			<div class="image-viewer">
-				{% for img in imgs %}
-					<img src="{{ img }}" />
-				{% endfor %}
-			</div>
-
+			{% if imgs %}<div class="image-viewer">{% for img in imgs %}<img src="{{ img }}" alt="Vehicle image">{% endfor %}</div>{% endif %}
 			<div class="listing-title">
 				{{ listing.title }}
-				{% if is_downgraded %}
-					<span class="downgrade-tag">Downgraded</span>
-				{% endif %}
-				<a class="visor-link" href="{{ listing.visor_listing }}"
-					>View on Visor ↗</a
-				>
+				<span class="deal-rating">{{ deal }}</span>
+				{% if is_downgraded %}<span class="downgrade-tag">Downgraded</span>{% endif %}
+				<a class="visor-link" href="{{ listing.visor_listing }}">View on Visor</a>
 			</div>
-
 			<div class="listing-title-bar"></div>
 			<div class="listing-specs compact-grid">
-				<div class="listing-specs-item">VIN: <strong>{{ vin }}</strong></div>
-				<div class="listing-specs-item">
-					Mileage: <strong>{{ miles(listing.mileage) }}</strong>
+				<div>VIN: <strong>{{ vin }}</strong></div>
+				<div>Mileage: <strong>{{ miles(listing.mileage) }}</strong></div>
+				<div>Listing Price: <strong>{{ money(listing.price) }}</strong></div>
+				<div>Risk Score: <strong>{{ risk }}</strong></div>
+				<div>Dealer: <strong>{{ seller_name }} - {{ seller_location }}</strong></div>
+				<div><a class="dealer-link" href="{{ listing.dealer_listing }}">View Dealer Listing</a></div>
+			</div>
+			<div class="price-position">
+				<div class="price-track">
+					<div class="price-segment great" style="width: {{ pricing.great_end_pct }}%;">Great</div>
+					<div class="price-segment good" style="left: {{ pricing.great_end_pct }}%; width: {{ pricing.good_end_pct - pricing.great_end_pct }}%;">Good</div>
+					<div class="price-segment fair" style="left: {{ pricing.good_end_pct }}%; width: {{ pricing.fair_end_pct - pricing.good_end_pct }}%;">Fair</div>
+					<div class="price-segment poor" style="left: {{ pricing.fair_end_pct }}%; width: {{ pricing.poor_end_pct - pricing.fair_end_pct }}%;">Poor</div>
+					<div class="price-segment bad" style="left: {{ pricing.poor_end_pct }}%; width: {{ 100 - pricing.poor_end_pct }}%;">Bad</div>
+					<div class="listing-marker" style="left: {{ pricing.marker_pct }}%;"><span></span></div>
 				</div>
-				<div class="listing-specs-item">
-					Listing Price: <strong>{{ money(listing.price) }}</strong>
-				</div>
-				<div class="listing-specs-item">
-					Risk Score: <strong>{{ risk }}</strong>
-				</div>
-				<div class="listing-specs-item">
-					Dealer: <strong>{{ seller_name }} - {{ seller_location }}</strong>
-				</div>
-				<div class="listing-specs-item">
-					<a class="dealer-link" href="{{ listing.dealer_listing }}"
-						>View Dealer Listing ↗</a
-					>
+				<div class="price-cutoffs">
+					<span style="left: {{ pricing.great_end_pct }}%;">{{ money(pricing.great_high) }}</span>
+					<span style="left: {{ pricing.good_end_pct }}%;">{{ money(pricing.good_high) }}</span>
+					<span style="left: {{ pricing.fair_end_pct }}%;">{{ money(pricing.fair_high) }}</span>
+					<span style="left: {{ pricing.poor_end_pct }}%;">{{ money(pricing.poor_high) }}</span>
 				</div>
 			</div>
-			<div class="listing-notes">
-				<strong>Notes:</strong>
-				<ul>
-					{% for line in narrative %}
-						<li class="note-line">{{ line }}</li>
-					{% endfor %}
-				</ul>
-			</div>
+			<div class="listing-notes"><strong>Notes:</strong><ul>{% for line in narrative %}<li>{{ line }}</li>{% endfor %}</ul></div>
 		{%- endmacro %}
 
-		{% macro render_bin(emoji, title, cls, bin, skip_break) -%}
-			{% if bin|length > 0 %}
-				<h2 class="section-header {{ 'break-before' if not skip_break }}">
-					{{ emoji }} {{ title }} Deals
-				</h2>
-				<div class="deal-bin">
-					{% for rating in bin %}
-						<div class="listing {{ cls }}">{{ vehicle_row(rating) }}</div>
-					{% endfor %}
-				</div>
-			{% endif %}
-		{%- endmacro %}
+		<main class="deal-bin">
+			{% for rating in all_ratings %}<article class="listing {{ rating[1]|lower }}-listing">{{ vehicle_row(rating) }}</article>{% endfor %}
+		</main>
 
-		{% macro candidate_row(candidate) -%}
-			{% set listing = candidate[0] %}
-			{% set assessment = candidate[1] %}
-			{% set narrative = candidate[2] %}
-			<div class="listing pending-listing">
-				<div class="listing-title">{{ listing.title }}{% if listing.visor_listing %}<a class="visor-link" href="{{ listing.visor_listing }}">View on Visor</a>{% endif %}</div>
-				<div class="listing-title-bar"></div>
-				<div class="listing-specs compact-grid">
-					<div class="listing-specs-item">VIN: <strong>{{ listing.vin or "N/A" }}</strong></div>
-					<div class="listing-specs-item">Mileage: <strong>{{ miles(listing.mileage) if listing.mileage is not none else "N/A" }}</strong></div>
-					<div class="listing-specs-item">Listing Price: <strong>{{ money(listing.price) if listing.price is not none else "N/A" }}</strong></div>
-					<div class="listing-specs-item">Price Assessment: <strong>{{ assessment }}</strong></div>
-					<div class="listing-specs-item">Risk: <strong>Not enough evidence</strong></div>
-					<div class="listing-specs-item">Final Level 2 Rating: <strong>Pending history report</strong></div>
-				</div>
-				<div class="listing-notes"><strong>Notes:</strong><ul>{% for line in narrative %}<li class="note-line">{{ line }}</li>{% endfor %}</ul></div>
-			</div>
-		{%- endmacro %}
+		{% if information_summary %}
+			<section class="unable-summary">
+				<h2>Unable to Evaluate</h2>
+				<p>These listings are excluded from individual display:</p>
+				<ul>{% for reason, count in information_summary %}<li>{{ reason }} <strong>({{ count }})</strong></li>{% endfor %}</ul>
+			</section>
+		{% endif %}
 
-		{% macro information_row(item) -%}
-			{% set listing = item[0] %}
-			<div class="listing unavailable-listing">
-				<div class="listing-title">{{ listing.title or "Untitled listing" }}{% if listing.visor_listing %}<a class="visor-link" href="{{ listing.visor_listing }}">View on Visor</a>{% endif %}</div>
-				<div class="listing-title-bar"></div>
-				<div class="listing-specs compact-grid">
-					<div class="listing-specs-item">VIN: <strong>{{ listing.vin or "N/A" }}</strong></div>
-					<div class="listing-specs-item">Listing Price: <strong>{{ money(listing.price) if listing.price is not none else "N/A" }}</strong></div>
-					<div class="listing-specs-item">Status: <strong>Unable to evaluate</strong></div>
-				</div>
-				<div class="listing-notes"><strong>Reason:</strong> {{ item[1] }}</div>
-			</div>
-		{%- endmacro %}
-		<section>
-			<!-- #region Deal Ratings -->
-			{%
-				set bins = [
-					{"emoji":"🟢","title":"Great","cls":"great-listing","bin":great_bin},
-					{"emoji":"🔵","title":"Good","cls":"good-listing","bin":good_bin},
-					{"emoji":"🟡","title":"Fair","cls":"fair-listing","bin":fair_bin},
-				]
-			%}
-			{# Calculate the first non-empty bin so we don't add unnecessary page breaks #}
-			{# Must use as namespace in order for it to save value #}
-			{% set state = namespace(first_nonempty_index=None) %}
-			{% for b in bins %}
-				{% if b.bin|length > 0 and state.first_nonempty_index is none %}
-					{% set state.first_nonempty_index = loop.index0 %}
-				{% endif %}
-			{% endfor %}
-			{# Display bins #}
-			{% for b in bins %}
-				{{ render_bin(b.emoji, b.title, b.cls, b.bin, loop.index0 == state.first_nonempty_index) }}
-			{% endfor %}
-			{{ render_bin("", "Poor", "poor-listing", rating_bins.Poor, false) }}
-			{{ render_bin("", "Bad", "bad-listing", rating_bins.Bad, false) }}
-			{{ render_bin("", "Suspicious", "suspicious-listing", rating_bins.Suspicious, false) }}
-			<div class="filtered-out">
-				<div class="no-break">
-					<h3>Unfavorable complete ratings:</h3>
-					<div>
-						🟠 {{ poor_count }} Poor Deals, 🔴 {{ bad_count }} Bad Deals, 🕵️
-						{{ sus_count }} Suspicious Deals
-					</div>
-				</div>
-			</div>
-
-			{% if price_only %}
-				<h2 class="section-header break-before">Awaiting History Report</h2>
-				<p>These listings have compatible KBB pricing, but their price assessment is not a complete Level 2 rating.</p>
-				{% for candidate in price_only %}{{ candidate_row(candidate) }}{% endfor %}
-			{% endif %}
-
-			{% if information_only %}
-				<h2 class="section-header break-before">Unable to Evaluate</h2>
-				{% for item in information_only %}{{ information_row(item) }}{% endfor %}
-			{% endif %}
-
-			<!-- #endregion -->
-		</section>
+		<footer>
+			<h2>How ratings work</h2>
+			<ul>
+				<li>Price is compared with local KBB Fair Purchase Price, then national FPP or Fair Market Value when needed.</li>
+				<li>A complete rating requires a vehicle-history report. Title, accident, odometer, mileage, service, and warranty evidence can change the risk score and downgrade the deal.</li>
+				<li>Listings without a history report, price, or compatible KBB data are summarized by reason rather than displayed individually.</li>
+				<li>CARFAX warranty status is an estimate and should be confirmed with the manufacturer or dealer.</li>
+			</ul>
+		</footer>
 	</body>
-	<footer>
-		<div style="page-break-before: always;"></div>
-		<div>
-			<h2>Methodology</h2>
-			<ul>
-				<li>A complete rating requires compatible KBB pricing and an available vehicle-history report.</li>
-				<li>Listings without a history report receive a price assessment only; risk and the final Level 2 rating remain unavailable.</li>
-				<li>
-					Deal ratings are based on this order: local fair purchase price (FPP),
-					national FPP, and then fair market value (FMV).
-				</li>
-				<li>
-					Bin sizes change based on the available pricing data. For local FPP,
-					we use the low and high market range to calculate bins. For national
-					FPP and FMV, we default to a $2000 or 6% price spread, whichever is
-					bigger.
-				</li>
-				<li>
-					Risk scoring considers branded titles, accidents/damage and their
-					severity, whether airbags were deployed, structural indicators,
-					odometer deviations, miles driven, and warranty status.
-				</li>
-				<li>Risk can downgrade a deal to a lower value.</li>
-				<li>Every returned listing is shown, including unfavorable deals and listings that could not be evaluated.</li>
-			</ul>
-		</div>
-		<div>
-			<h2>Definitions and Clarifications</h2>
-			<h4>Deal Bin/Pricing Calculations</h4>
-			<p>
-				When we search Kelley Blue Books for pricing data, we obtain 4 price
-				amounts:
-			</p>
-			<ul>
-				<li>
-					MRSP, the factory-set price (which we do not use for calculations at
-					this stage)
-				</li>
-				<li>
-					National Fair Purchase Price (FPP), the average price this particular
-					year and model are sold nationally
-				</li>
-				<li>Local Fair Purchase Price, which is based on your area</li>
-				<li>
-					Fair Market Value (FMV), which is the price this vehicle would be sold
-					privately and not through a dealership
-				</li>
-			</ul>
-			<p>
-				We use the local FPP first, as it gives us a fair market range to work
-				with. Using that range, we can calculate exactly what a Fair, Good, or
-				Great deal will be. In the absence of a local FPP, we use the national
-				FPP, but we must default to a set dollar amount for calculating deal
-				strength. If that fails, we rely on FMV, following the same rules as the
-				national FPP.
-			</p>
-			<p>
-				These numbers will vary across years and trims, which is why they all
-				have different bin and midpoint values.
-			</p>
-
-			<h4>Mileage Deviations</h4>
-			<p>
-				Mileage deviation refers to the amount of miles a vehicle has been
-				driven more or less than the industry average of 15,000. This number is
-				used by the US Government, Kelley Blue Books, and Carfax.
-			</p>
-			<h4>Structural indicators</h4>
-			<p>
-				When an impact occurs, there is always risk of structural issues. The
-				greater the damage, the more chance there is a problem. We grade it on a
-				scale, with minor damages slightly impacting this part of the risk, and
-				major or severe damage impacting it greatly. This cannot be confirmed
-				through a Carfax report, so an inspection is highly recommended.
-			</p>
-			<h4>Warranty Status</h4>
-			<p>
-				Warranty status only indicates the basic out-of-the-factory warranty.
-				When an accident occurs, that warranty is usually voided. The lack of
-				warranty does not impact the risk, but warranty still in place can lower
-				the risk level.
-			</p>
-		</div>
-	</footer>
 </html>

--- a/templates/level2.html
+++ b/templates/level2.html
@@ -19,7 +19,7 @@
 		<section class="intro">
 			<p class="generated">Generated: {{ generated_at }}</p>
 			<p>This report compares each listing with compatible KBB pricing. When a vehicle-history report is available, it also evaluates title, accident, mileage, service, and warranty evidence to produce a complete rating.</p>
-			<div class="rating-guide"><strong>Reading each rating:</strong> The white triangle shows the evidence-adjusted price position across the colored deal scale; the prices below it are rating cutoffs. The percentage marker on the solid bar at the left shows strength within the assigned rating. A higher percentage means the vehicle is closer to the next-better rating; it is not a confidence score.</div>
+			<div class="rating-guide"><strong>Reading each rating:</strong> The white triangle shows the evidence-adjusted price position across the colored deal scale; the prices below it are rating cutoffs. Deal Score uses that entire scale, from 100% at the strongest end to 0% at the weakest. It is not a confidence score.</div>
 			<p class="footnote">A complete Level 2 rating requires both compatible KBB pricing and a vehicle-history report. Listings without that evidence receive a price assessment or are counted under an evaluation failure reason.</p>
 		</section>
 
@@ -50,6 +50,8 @@
 				<a class="visor-link" href="{{ listing.visor_listing }}">View on Visor</a>
 			</div>
 			<div class="listing-title-bar"></div>
+			<div class="listing-evaluation{% if pricing.deal_score is not none %} has-score{% endif %}">
+			<div class="listing-measures">
 			<div class="listing-specs compact-grid">
 				<div>VIN: <strong>{{ vin }}</strong></div>
 				<div>Mileage: <strong>{{ miles(listing.mileage) }}</strong></div>
@@ -74,13 +76,16 @@
 					<span data-left-pct="{{ pricing.poor_end_pct }}">{{ money(pricing.poor_high) }}</span>
 				</div>
 			</div>
+			</div>
+			{% if pricing.deal_score is not none %}<div class="deal-score"><strong>Deal Score</strong><span>{{ pricing.deal_score|round|int }}%</span></div>{% endif %}
+			</div>
 			<div class="listing-notes"><strong>Notes:</strong><ul>{% for line in narrative %}<li>{{ line }}</li>{% endfor %}</ul></div>
 			</div>
 			</div>
 		{%- endmacro %}
 
 		<main class="deal-bin">
-			{% for rating in all_ratings %}<article class="listing {{ rating[1]|lower }}-listing"><div class="deal-strength-track">{% if rating[4].deal_strength is not none %}<span class="deal-strength-marker{% if rating[4].deal_strength >= 90 %} marker-high{% elif rating[4].deal_strength <= 10 %} marker-low{% endif %}" data-bottom-pct="{{ rating[4].deal_strength }}"><b>{{ rating[4].deal_strength|round|int }}%</b></span>{% endif %}</div>{{ vehicle_row(rating) }}</article>{% endfor %}
+			{% for rating in all_ratings %}<article class="listing {{ rating[1]|lower }}-listing">{{ vehicle_row(rating) }}</article>{% endfor %}
 		</main>
 
 		{% if information_summary %}

--- a/templates/level2.html
+++ b/templates/level2.html
@@ -19,6 +19,7 @@
 		<section class="intro">
 			<p class="generated">Generated: {{ generated_at }}</p>
 			<p>This report compares each listing with compatible KBB pricing. When a vehicle-history report is available, it also evaluates title, accident, mileage, service, and warranty evidence to produce a complete rating.</p>
+			<div class="rating-guide"><strong>Reading each rating:</strong> The white triangle shows the evidence-adjusted price position across the colored deal scale; the prices below it are rating cutoffs. The colored bar at the left of each vehicle shows strength within its assigned rating—a fuller bar means it is closer to the next-better rating. It is not a confidence score.</div>
 			<p class="footnote">A complete Level 2 rating requires both compatible KBB pricing and a vehicle-history report. Listings without that evidence receive a price assessment or are counted under an evaluation failure reason.</p>
 		</section>
 
@@ -42,7 +43,7 @@
 			{% if imgs %}<div class="image-viewer">{% for img in imgs %}<img src="{{ img }}" alt="Vehicle image">{% endfor %}</div>{% endif %}
 			<div class="listing-title">
 				{{ listing.title }}
-				<span class="deal-rating">{{ deal }}</span>
+				<span class="deal-rating">{{ deal }}{% if pricing.deal_strength is not none %} · {{ pricing.deal_strength|round|int }}%{% endif %}</span>
 				{% if is_downgraded %}<span class="downgrade-tag">Downgraded</span>{% endif %}
 				<a class="visor-link" href="{{ listing.visor_listing }}">View on Visor</a>
 			</div>
@@ -56,13 +57,13 @@
 				<div><a class="dealer-link" href="{{ listing.dealer_listing }}">View Dealer Listing</a></div>
 			</div>
 			<div class="price-position">
-				<div class="price-track">
+				<div class="price-track" data-great-end-pct="{{ pricing.great_end_pct }}" data-good-end-pct="{{ pricing.good_end_pct }}" data-fair-end-pct="{{ pricing.fair_end_pct }}" data-poor-end-pct="{{ pricing.poor_end_pct }}">
 					<div class="price-segment great" data-width-pct="{{ pricing.great_end_pct }}">Great</div>
 					<div class="price-segment good" data-left-pct="{{ pricing.great_end_pct }}" data-width-pct="{{ pricing.good_end_pct - pricing.great_end_pct }}">Good</div>
 					<div class="price-segment fair" data-left-pct="{{ pricing.good_end_pct }}" data-width-pct="{{ pricing.fair_end_pct - pricing.good_end_pct }}">Fair</div>
 					<div class="price-segment poor" data-left-pct="{{ pricing.fair_end_pct }}" data-width-pct="{{ pricing.poor_end_pct - pricing.fair_end_pct }}">Poor</div>
 					<div class="price-segment bad" data-left-pct="{{ pricing.poor_end_pct }}" data-width-pct="{{ 100 - pricing.poor_end_pct }}">Bad</div>
-					<div class="listing-marker" data-left-pct="{{ pricing.marker_pct }}"><span></span></div>
+					<div class="listing-marker" data-left-pct="{{ pricing.marker_pct }}"></div>
 				</div>
 				<div class="price-cutoffs">
 					<span data-left-pct="{{ pricing.great_end_pct }}">{{ money(pricing.great_high) }}</span>
@@ -75,7 +76,7 @@
 		{%- endmacro %}
 
 		<main class="deal-bin">
-			{% for rating in all_ratings %}<article class="listing {{ rating[1]|lower }}-listing">{{ vehicle_row(rating) }}</article>{% endfor %}
+			{% for rating in all_ratings %}<article class="listing {{ rating[1]|lower }}-listing"><div class="deal-strength-track">{% if rating[4].deal_strength is not none %}<span data-height-pct="{{ rating[4].deal_strength }}"></span>{% endif %}</div>{{ vehicle_row(rating) }}</article>{% endfor %}
 		</main>
 
 		{% if information_summary %}
@@ -90,7 +91,7 @@
 			<h2>How ratings work</h2>
 			<ul>
 				<li>Price is compared with local KBB Fair Purchase Price, then national FPP or Fair Market Value when needed.</li>
-				<li>A complete rating requires a vehicle-history report. Title, accident, odometer, mileage, service, and warranty evidence can change the risk score and downgrade the deal.</li>
+				<li>A complete rating requires a vehicle-history report. Title, accident, odometer, mileage, service, and warranty evidence can improve or worsen the price-based rating.</li>
 				<li>Listings without a history report, price, or compatible KBB data are summarized by reason rather than displayed individually.</li>
 				<li>CARFAX warranty status is an estimate and should be confirmed with the manufacturer or dealer.</li>
 			</ul>

--- a/templates/level2.html
+++ b/templates/level2.html
@@ -57,18 +57,18 @@
 			</div>
 			<div class="price-position">
 				<div class="price-track">
-					<div class="price-segment great" style="width: {{ pricing.great_end_pct }}%;">Great</div>
-					<div class="price-segment good" style="left: {{ pricing.great_end_pct }}%; width: {{ pricing.good_end_pct - pricing.great_end_pct }}%;">Good</div>
-					<div class="price-segment fair" style="left: {{ pricing.good_end_pct }}%; width: {{ pricing.fair_end_pct - pricing.good_end_pct }}%;">Fair</div>
-					<div class="price-segment poor" style="left: {{ pricing.fair_end_pct }}%; width: {{ pricing.poor_end_pct - pricing.fair_end_pct }}%;">Poor</div>
-					<div class="price-segment bad" style="left: {{ pricing.poor_end_pct }}%; width: {{ 100 - pricing.poor_end_pct }}%;">Bad</div>
-					<div class="listing-marker" style="left: {{ pricing.marker_pct }}%;"><span></span></div>
+					<div class="price-segment great" data-width-pct="{{ pricing.great_end_pct }}">Great</div>
+					<div class="price-segment good" data-left-pct="{{ pricing.great_end_pct }}" data-width-pct="{{ pricing.good_end_pct - pricing.great_end_pct }}">Good</div>
+					<div class="price-segment fair" data-left-pct="{{ pricing.good_end_pct }}" data-width-pct="{{ pricing.fair_end_pct - pricing.good_end_pct }}">Fair</div>
+					<div class="price-segment poor" data-left-pct="{{ pricing.fair_end_pct }}" data-width-pct="{{ pricing.poor_end_pct - pricing.fair_end_pct }}">Poor</div>
+					<div class="price-segment bad" data-left-pct="{{ pricing.poor_end_pct }}" data-width-pct="{{ 100 - pricing.poor_end_pct }}">Bad</div>
+					<div class="listing-marker" data-left-pct="{{ pricing.marker_pct }}"><span></span></div>
 				</div>
 				<div class="price-cutoffs">
-					<span style="left: {{ pricing.great_end_pct }}%;">{{ money(pricing.great_high) }}</span>
-					<span style="left: {{ pricing.good_end_pct }}%;">{{ money(pricing.good_high) }}</span>
-					<span style="left: {{ pricing.fair_end_pct }}%;">{{ money(pricing.fair_high) }}</span>
-					<span style="left: {{ pricing.poor_end_pct }}%;">{{ money(pricing.poor_high) }}</span>
+					<span data-left-pct="{{ pricing.great_end_pct }}">{{ money(pricing.great_high) }}</span>
+					<span data-left-pct="{{ pricing.good_end_pct }}">{{ money(pricing.good_high) }}</span>
+					<span data-left-pct="{{ pricing.fair_end_pct }}">{{ money(pricing.fair_high) }}</span>
+					<span data-left-pct="{{ pricing.poor_end_pct }}">{{ money(pricing.poor_high) }}</span>
 				</div>
 			</div>
 			<div class="listing-notes"><strong>Notes:</strong><ul>{% for line in narrative %}<li>{{ line }}</li>{% endfor %}</ul></div>

--- a/templates/level2.html
+++ b/templates/level2.html
@@ -19,7 +19,7 @@
 		<section class="intro">
 			<p class="generated">Generated: {{ generated_at }}</p>
 			<p>This report compares each listing with compatible KBB pricing. When a vehicle-history report is available, it also evaluates title, accident, mileage, service, and warranty evidence to produce a complete rating.</p>
-			<div class="rating-guide"><strong>Reading each rating:</strong> The white triangle shows the evidence-adjusted price position across the colored deal scale; the prices below it are rating cutoffs. The colored bar at the left of each vehicle shows strength within its assigned rating—a fuller bar means it is closer to the next-better rating. It is not a confidence score.</div>
+			<div class="rating-guide"><strong>Reading each rating:</strong> The white triangle shows the evidence-adjusted price position across the colored deal scale; the prices below it are rating cutoffs. The percentage marker on the solid bar at the left shows strength within the assigned rating. A higher percentage means the vehicle is closer to the next-better rating; it is not a confidence score.</div>
 			<p class="footnote">A complete Level 2 rating requires both compatible KBB pricing and a vehicle-history report. Listings without that evidence receive a price assessment or are counted under an evaluation failure reason.</p>
 		</section>
 
@@ -43,7 +43,7 @@
 			{% if imgs %}<div class="image-viewer">{% for img in imgs %}<img src="{{ img }}" alt="Vehicle image">{% endfor %}</div>{% endif %}
 			<div class="listing-title">
 				{{ listing.title }}
-				<span class="deal-rating">{{ deal }}{% if pricing.deal_strength is not none %} · {{ pricing.deal_strength|round|int }}%{% endif %}</span>
+				<span class="deal-rating">{{ deal }}</span>
 				{% if is_downgraded %}<span class="downgrade-tag">Downgraded</span>{% endif %}
 				<a class="visor-link" href="{{ listing.visor_listing }}">View on Visor</a>
 			</div>
@@ -76,7 +76,7 @@
 		{%- endmacro %}
 
 		<main class="deal-bin">
-			{% for rating in all_ratings %}<article class="listing {{ rating[1]|lower }}-listing"><div class="deal-strength-track">{% if rating[4].deal_strength is not none %}<span data-height-pct="{{ rating[4].deal_strength }}"></span>{% endif %}</div>{{ vehicle_row(rating) }}</article>{% endfor %}
+			{% for rating in all_ratings %}<article class="listing {{ rating[1]|lower }}-listing"><div class="deal-strength-track">{% if rating[4].deal_strength is not none %}<span class="deal-strength-marker" data-bottom-pct="{{ rating[4].deal_strength }}"><b>{{ rating[4].deal_strength|round|int }}%</b></span>{% endif %}</div>{{ vehicle_row(rating) }}</article>{% endfor %}
 		</main>
 
 		{% if information_summary %}

--- a/templates/level2.html
+++ b/templates/level2.html
@@ -15,15 +15,17 @@
 				title status, and other long-term risk factors influencing fair value.
 			</p>
 			<p class="footnote">
-				Only vehicles with a Carfax report have been analyzed.
+				A complete Level 2 rating requires both compatible KBB pricing and a
+				vehicle-history report. Listings without that evidence remain visible
+				below as price assessments or information-only listings.
 			</p>
 		</section>
 
-		{{ valid_count }} listings were eligible for Level 2 analysis. Of those
-		listings, <strong>{{ great_bin|length }}</strong> are considered a great
-		deal, <strong>{{ good_bin|length }}</strong> are considered a good deal, and
-		<strong>{{ fair_bin|length }}</strong> are considered a fair deal.
-		<strong>Deals are sorted from best to worst.</strong>
+		Of {{ total_count }} returned listings, <strong>{{ full_count }}</strong>
+		received a complete risk-adjusted Level 2 rating,
+		<strong>{{ price_only|length }}</strong> received a price assessment while
+		awaiting a history report, and <strong>{{ information_only|length }}</strong>
+		could not be evaluated. <strong>Every returned listing is shown.</strong>
 		{% macro miles(n) -%}{{ "{:,}".format(n) }}{%- endmacro %}
 		{% macro money(n) -%}{{ "${:,.0f}".format(n) }}{%- endmacro %}
 
@@ -99,6 +101,39 @@
 				</div>
 			{% endif %}
 		{%- endmacro %}
+
+		{% macro candidate_row(candidate) -%}
+			{% set listing = candidate[0] %}
+			{% set assessment = candidate[1] %}
+			{% set narrative = candidate[2] %}
+			<div class="listing pending-listing">
+				<div class="listing-title">{{ listing.title }}{% if listing.visor_listing %}<a class="visor-link" href="{{ listing.visor_listing }}">View on Visor</a>{% endif %}</div>
+				<div class="listing-title-bar"></div>
+				<div class="listing-specs compact-grid">
+					<div class="listing-specs-item">VIN: <strong>{{ listing.vin or "N/A" }}</strong></div>
+					<div class="listing-specs-item">Mileage: <strong>{{ miles(listing.mileage) if listing.mileage is not none else "N/A" }}</strong></div>
+					<div class="listing-specs-item">Listing Price: <strong>{{ money(listing.price) if listing.price is not none else "N/A" }}</strong></div>
+					<div class="listing-specs-item">Price Assessment: <strong>{{ assessment }}</strong></div>
+					<div class="listing-specs-item">Risk: <strong>Not enough evidence</strong></div>
+					<div class="listing-specs-item">Final Level 2 Rating: <strong>Pending history report</strong></div>
+				</div>
+				<div class="listing-notes"><strong>Notes:</strong><ul>{% for line in narrative %}<li class="note-line">{{ line }}</li>{% endfor %}</ul></div>
+			</div>
+		{%- endmacro %}
+
+		{% macro information_row(item) -%}
+			{% set listing = item[0] %}
+			<div class="listing unavailable-listing">
+				<div class="listing-title">{{ listing.title or "Untitled listing" }}{% if listing.visor_listing %}<a class="visor-link" href="{{ listing.visor_listing }}">View on Visor</a>{% endif %}</div>
+				<div class="listing-title-bar"></div>
+				<div class="listing-specs compact-grid">
+					<div class="listing-specs-item">VIN: <strong>{{ listing.vin or "N/A" }}</strong></div>
+					<div class="listing-specs-item">Listing Price: <strong>{{ money(listing.price) if listing.price is not none else "N/A" }}</strong></div>
+					<div class="listing-specs-item">Status: <strong>Unable to evaluate</strong></div>
+				</div>
+				<div class="listing-notes"><strong>Reason:</strong> {{ item[1] }}</div>
+			</div>
+		{%- endmacro %}
 		<section>
 			<!-- #region Deal Ratings -->
 			{%
@@ -120,15 +155,29 @@
 			{% for b in bins %}
 				{{ render_bin(b.emoji, b.title, b.cls, b.bin, loop.index0 == state.first_nonempty_index) }}
 			{% endfor %}
+			{{ render_bin("", "Poor", "poor-listing", rating_bins.Poor, false) }}
+			{{ render_bin("", "Bad", "bad-listing", rating_bins.Bad, false) }}
+			{{ render_bin("", "Suspicious", "suspicious-listing", rating_bins.Suspicious, false) }}
 			<div class="filtered-out">
 				<div class="no-break">
-					<h3>Filtered out:</h3>
+					<h3>Unfavorable complete ratings:</h3>
 					<div>
 						🟠 {{ poor_count }} Poor Deals, 🔴 {{ bad_count }} Bad Deals, 🕵️
 						{{ sus_count }} Suspicious Deals
 					</div>
 				</div>
 			</div>
+
+			{% if price_only %}
+				<h2 class="section-header break-before">Awaiting History Report</h2>
+				<p>These listings have compatible KBB pricing, but their price assessment is not a complete Level 2 rating.</p>
+				{% for candidate in price_only %}{{ candidate_row(candidate) }}{% endfor %}
+			{% endif %}
+
+			{% if information_only %}
+				<h2 class="section-header break-before">Unable to Evaluate</h2>
+				{% for item in information_only %}{{ information_row(item) }}{% endfor %}
+			{% endif %}
 
 			<!-- #endregion -->
 		</section>
@@ -138,7 +187,8 @@
 		<div>
 			<h2>Methodology</h2>
 			<ul>
-				<li>Listings must have an available Carfax report to qualify.</li>
+				<li>A complete rating requires compatible KBB pricing and an available vehicle-history report.</li>
+				<li>Listings without a history report receive a price assessment only; risk and the final Level 2 rating remain unavailable.</li>
 				<li>
 					Deal ratings are based on this order: local fair purchase price (FPP),
 					national FPP, and then fair market value (FMV).
@@ -155,9 +205,7 @@
 					odometer deviations, miles driven, and warranty status.
 				</li>
 				<li>Risk can downgrade a deal to a lower value.</li>
-				<li>
-					Bad, Poor, and Suspicious deals are excluded from the main report.
-				</li>
+				<li>Every returned listing is shown, including unfavorable deals and listings that could not be evaluated.</li>
 			</ul>
 		</div>
 		<div>

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -1,0 +1,60 @@
+import io
+import shutil
+import uuid
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from PIL import Image
+from playwright._impl._errors import TimeoutError as PlaywrightTimeout
+
+from utils.download import download_images
+
+
+class Response:
+	ok = True
+
+	def __init__(self, data: bytes):
+		self.data = data
+
+	async def body(self):
+		return self.data
+
+
+class Request:
+	def __init__(self, response: Response):
+		self.response = response
+		self.calls = 0
+
+	async def get(self, url):
+		self.calls += 1
+		if self.calls == 1:
+			raise PlaywrightTimeout("image timed out")
+		return self.response
+
+
+@pytest.fixture
+def output_dir() -> Iterator[Path]:
+	path = Path("cache") / "test-image-download" / uuid.uuid4().hex
+	path.mkdir(parents=True)
+	try:
+		yield path
+	finally:
+		shutil.rmtree(path)
+
+
+async def test_image_timeout_does_not_abort_remaining_downloads(output_dir):
+	buffer = io.BytesIO()
+	Image.new("RGB", (2, 2)).save(buffer, format="JPEG")
+	request = Request(Response(buffer.getvalue()))
+	listing = {
+		"id": "listing-1",
+		"images": ["https://example.invalid/slow.jpg", "https://example.invalid/good.jpg"],
+	}
+
+	count = await download_images(request, listing, str(output_dir))
+
+	assert count == 1
+	assert (output_dir / "images" / "2.jpg").is_file()

--- a/tests/unit/test_level2_cache.py
+++ b/tests/unit/test_level2_cache.py
@@ -1,0 +1,118 @@
+import json
+import shutil
+import uuid
+
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from visor_api import VisorListingQuery, cached_level2_collection
+
+
+class CacheClient:
+	def __init__(self):
+		self.search_calls = 0
+		self.detail_calls = 0
+
+	def filter_all_listings(self, params=None, *, max_listings=50):
+		self.search_calls += 1
+		return {
+			"data": [{
+				"id": f"listing-{self.search_calls}",
+				"vin": f"VIN{self.search_calls}",
+				"year": 2024,
+				"make": "Subaru",
+				"model": "Crosstrek",
+			}],
+			"pagination": {
+				"limit": max_listings,
+				"offset": 0,
+				"total": 1,
+				"next_offset": None,
+			},
+			"meta": {},
+		}
+
+	def get_listing(self, listing_id, params=None):
+		self.detail_calls += 1
+		return {"data": {"id": listing_id, "vin": f"VIN{self.search_calls}"}}
+
+
+def query():
+	return VisorListingQuery.from_options({
+		"make": "Subaru",
+		"model": "Crosstrek",
+		"year": (2024, 2025, 2026),
+	})
+
+
+@pytest.fixture
+def cache_dir() -> Iterator[Path]:
+	path = Path("cache") / "test-level2-cache" / uuid.uuid4().hex
+	path.mkdir(parents=True)
+	try:
+		yield path
+	finally:
+		shutil.rmtree(path)
+
+
+def test_level2_cache_hit_and_force_refresh(cache_dir):
+	client = CacheClient()
+	clock = lambda: datetime(2026, 7, 21, tzinfo=timezone.utc)
+
+	first = cached_level2_collection(
+		client, query(), cache_dir=cache_dir, clock=clock
+	)
+	second = cached_level2_collection(
+		client, query(), cache_dir=cache_dir, clock=clock
+	)
+	forced = cached_level2_collection(
+		client, query(), cache_dir=cache_dir, clock=clock, force=True
+	)
+
+	assert first.cache_used is False
+	assert second.cache_used is True
+	assert forced.cache_used is False
+	assert second.collection == first.collection
+	assert forced.collection != first.collection
+	assert client.search_calls == 2
+	assert client.detail_calls == 2
+	assert first.cache_path == second.cache_path == forced.cache_path
+	envelope = json.loads(first.cache_path.read_text(encoding="utf-8"))
+	assert envelope["cache_schema"] == 1
+	assert envelope["collection"]["raw_search_response"]["data"][0]["id"] == "listing-2"
+
+
+def test_level2_cache_expires_after_local_day(cache_dir):
+	client = CacheClient()
+	local_zone = timezone(timedelta(hours=-6))
+
+	cached_level2_collection(
+		client,
+		query(),
+		cache_dir=cache_dir,
+		clock=lambda: datetime(2026, 7, 21, 23, 59, tzinfo=local_zone),
+	)
+	result = cached_level2_collection(
+		client,
+		query(),
+		cache_dir=cache_dir,
+		clock=lambda: datetime(2026, 7, 22, 0, 1, tzinfo=local_zone),
+	)
+
+	assert result.cache_used is False
+	assert client.search_calls == 2
+
+
+def test_corrupt_level2_cache_is_replaced(cache_dir):
+	client = CacheClient()
+	first = cached_level2_collection(client, query(), cache_dir=cache_dir)
+	first.cache_path.write_text("not json", encoding="utf-8")
+
+	result = cached_level2_collection(client, query(), cache_dir=cache_dir)
+
+	assert result.cache_used is False
+	assert client.search_calls == 2
+	assert json.loads(result.cache_path.read_text(encoding="utf-8"))["cache_schema"] == 1

--- a/tests/unit/test_level2_eligibility.py
+++ b/tests/unit/test_level2_eligibility.py
@@ -161,6 +161,25 @@ def test_price_assessment_provides_visual_range_without_redundant_bullets():
 	assert 0 <= visual["marker_pct"] <= 100
 	assert not any("being listed at" in line for line in narrative)
 	assert not any("Deal bins are set" in line for line in narrative)
+	assert "Listing price is 7.4% below the fair-price midpoint." in narrative
+
+
+def test_price_assessment_explains_percent_from_fair_midpoint():
+	lc = ListingContext(
+		listing_id="one",
+		listing={"price": 27500},
+		pricing=PricingAnchors(
+			fpp_natl=26000,
+			fpp_local=25000,
+			fmv=24000,
+			fmr_high=28000,
+		),
+	)
+	narrative = []
+
+	level2._price_assessment(lc, narrative)
+
+	assert "Listing price is 1.9% above the fair-price midpoint." in narrative
 
 
 def test_level2_branding_and_dealer_location_helpers():

--- a/tests/unit/test_level2_eligibility.py
+++ b/tests/unit/test_level2_eligibility.py
@@ -5,6 +5,7 @@ from analysis.reporting import (
 	build_level2_bins,
 	create_report_filter_summary,
 	display_dealer_location,
+	display_listing_condition,
 	logo_data_uri,
 	summarize_level2_failures,
 )
@@ -168,6 +169,9 @@ def test_level2_branding_and_dealer_location_helpers():
 	assert logo_data_uri(Path("img/deallens-logo.svg")).startswith(
 		"data:image/svg+xml;base64,"
 	)
+	assert display_listing_condition("Certified") == "CPO"
+	assert display_listing_condition("Used") == "Used"
+	assert display_listing_condition(None) == "Unknown"
 
 
 def test_level2_template_keeps_jinja_out_of_inline_css():

--- a/tests/unit/test_level2_eligibility.py
+++ b/tests/unit/test_level2_eligibility.py
@@ -176,4 +176,16 @@ def test_level2_template_keeps_jinja_out_of_inline_css():
 	assert "style=" not in template
 	assert "data-left-pct=" in template
 	assert "data-width-pct=" in template
-	assert "data-height-pct=" in template
+	assert "data-bottom-pct=" in template
+
+
+def test_level2_bins_sort_by_within_bin_strength():
+	ratings = [
+		({"price": 20000}, "Fair", 0, [], {"deal_strength": 20}),
+		({"price": 21000}, "Fair", 1, [], {"deal_strength": 80}),
+		({"price": 19000}, "Fair", 0, [], {"deal_strength": 50}),
+	]
+
+	bins = build_level2_bins(ratings)
+
+	assert [rating[4]["deal_strength"] for rating in bins["Fair"]] == [80, 50, 20]

--- a/tests/unit/test_level2_eligibility.py
+++ b/tests/unit/test_level2_eligibility.py
@@ -1,0 +1,71 @@
+from analysis import level2
+from analysis.reporting import build_level2_bins
+from utils.models import AnalysisContext, ListingContext
+
+
+async def test_level2_keeps_price_only_and_unmapped_listings(monkeypatch):
+	price_only_listing = {
+		"id": "price-only",
+		"vin": "VIN1",
+		"title": "Price-only vehicle",
+		"price": 25000,
+	}
+	unmapped_listing = {
+		"id": "unmapped",
+		"vin": "VIN2",
+		"title": "Unmapped vehicle",
+		"price": 26000,
+	}
+	ctx = AnalysisContext(make="Subaru", model="Forester")
+	ctx.listings = [ListingContext(listing_id="price-only", listing=price_only_listing)]
+	ctx.skipped_listings = [unmapped_listing]
+
+	async def fake_prepare(*_args, **_kwargs):
+		return ctx
+
+	async def fake_render(*args):
+		fake_render.args = args
+
+	monkeypatch.setattr(level2, "prepare_level2_analysis", fake_prepare)
+	monkeypatch.setattr(
+		level2,
+		"_price_assessment",
+		lambda _lc, narrative: narrative.append("Price evidence available.")
+		or ("Good", 0, 0, 0.0),
+	)
+	monkeypatch.setattr(level2, "render_level2_pdf", fake_render)
+
+	await level2.start_level2_analysis(
+		{"vehicle": {"make": "Subaru", "model": "Forester"}},
+		[price_only_listing, unmapped_listing],
+		"unused.json",
+	)
+
+	assert fake_render.args[3] == []
+	assert fake_render.args[4] == [
+		(
+			price_only_listing,
+			"Good",
+			[
+				"Price evidence available.",
+				"A vehicle-history report was not collected, so risk and the final Level 2 rating are unavailable.",
+			],
+		)
+	]
+	assert fake_render.args[5] == [
+		(unmapped_listing, "The listing trim could not be mapped to compatible KBB pricing.")
+	]
+
+
+def test_level2_bins_retain_unfavorable_complete_ratings():
+	ratings = [
+		({"id": "poor", "price": 20000}, "Poor", 2, []),
+		({"id": "bad", "price": 21000}, "Bad", 3, []),
+		({"id": "suspicious", "price": 10000}, "Suspicious", 7, []),
+	]
+
+	bins = build_level2_bins(ratings)
+
+	assert bins["Poor"] == [ratings[0]]
+	assert bins["Bad"] == [ratings[1]]
+	assert bins["Suspicious"] == [ratings[2]]

--- a/tests/unit/test_level2_eligibility.py
+++ b/tests/unit/test_level2_eligibility.py
@@ -1,6 +1,15 @@
+from pathlib import Path
+
 from analysis import level2
-from analysis.reporting import build_level2_bins
-from utils.models import AnalysisContext, ListingContext
+from analysis.reporting import (
+	build_level2_bins,
+	create_report_filter_summary,
+	display_dealer_location,
+	logo_data_uri,
+	summarize_level2_failures,
+)
+from jinja2 import Environment, FileSystemLoader
+from utils.models import AnalysisContext, ListingContext, PricingAnchors
 
 
 async def test_level2_keeps_price_only_and_unmapped_listings(monkeypatch):
@@ -69,3 +78,93 @@ def test_level2_bins_retain_unfavorable_complete_ratings():
 	assert bins["Poor"] == [ratings[0]]
 	assert bins["Bad"] == [ratings[1]]
 	assert bins["Suspicious"] == [ratings[2]]
+
+
+def test_report_summary_accepts_single_condition_string():
+	summary = create_report_filter_summary(
+		{"filters": {"car_type": "used", "sort": "Newest"}}
+	)
+
+	assert "Used listings" in summary
+	assert "New, Used, and Certified" not in summary
+
+
+def test_report_summarizes_unevaluated_reasons_without_listing_rows():
+	template = Environment(loader=FileSystemLoader("templates")).get_template(
+		"level2.html"
+	)
+	empty_bins = {
+		name: [] for name in ("Great", "Good", "Fair", "Poor", "Bad", "Suspicious")
+	}
+	html = template.render(
+		make="Subaru",
+		model="Forester",
+		report_title="Level 2",
+		generated_at="today",
+		summary="Used listings",
+		total_count=2,
+		full_count=0,
+		price_only=[],
+		information_only=[({"vin": "HIDDENVIN"}, "KBB pricing unavailable")],
+		information_summary=[("KBB pricing unavailable", 2)],
+		rating_bins=empty_bins,
+		great_bin=[],
+		good_bin=[],
+		fair_bin=[],
+		poor_count=0,
+		bad_count=0,
+		sus_count=0,
+		all_images={},
+	)
+
+	assert "KBB pricing unavailable <strong>(2)</strong>" in html
+	assert "HIDDENVIN" not in html
+
+
+def test_price_only_listings_are_grouped_with_other_failure_reasons():
+	summary = summarize_level2_failures(
+		[({"id": "one"}, "Good", []), ({"id": "two"}, "Fair", [])],
+		[({"id": "three"}, "Listing price is unavailable.")],
+	)
+
+	assert summary == [
+		("Listing price is unavailable.", 1),
+		("Vehicle-history report unavailable.", 2),
+	]
+
+
+def test_price_assessment_provides_visual_range_without_redundant_bullets():
+	lc = ListingContext(
+		listing_id="one",
+		listing={"price": 25000},
+		pricing=PricingAnchors(
+			fpp_natl=26000,
+			fpp_local=25000,
+			fmv=24000,
+			fmr_high=28000,
+		),
+	)
+	narrative = []
+
+	assessment = level2._price_assessment(lc, narrative)
+
+	assert assessment is not None
+	visual = assessment[4]
+	assert visual["fair_low"] < visual["fair_high"]
+	assert (
+		visual["great_high"]
+		< visual["good_high"]
+		< visual["fair_high"]
+		< visual["poor_high"]
+	)
+	assert 0 <= visual["marker_pct"] <= 100
+	assert not any("being listed at" in line for line in narrative)
+	assert not any("Deal bins are set" in line for line in narrative)
+
+
+def test_level2_branding_and_dealer_location_helpers():
+	assert display_dealer_location("Denver, CO 80202") == "Denver, CO"
+	assert display_dealer_location("Denver, CO") == "Denver, CO"
+	assert logo_data_uri(Path("img/deallens-logo.svg")).startswith(
+		"data:image/svg+xml;base64,"
+	)

--- a/tests/unit/test_level2_eligibility.py
+++ b/tests/unit/test_level2_eligibility.py
@@ -67,6 +67,79 @@ async def test_level2_keeps_price_only_and_unmapped_listings(monkeypatch):
 	]
 
 
+async def test_level2_records_missing_complete_kbb_pricing(monkeypatch):
+	listing = {
+		"id": "incomplete-kbb",
+		"vin": "VIN3",
+		"title": "Incomplete KBB vehicle",
+		"price": 25_000,
+	}
+	ctx = AnalysisContext(make="Subaru", model="Forester")
+	ctx.listings = [ListingContext(
+		listing_id="incomplete-kbb",
+		listing=listing,
+		pricing=PricingAnchors(
+			fpp_natl=26_000,
+			fpp_local=None,
+			fmv=24_000,
+			fmr_high=28_000,
+		),
+	)]
+
+	async def fake_prepare(*_args, **_kwargs):
+		return ctx
+
+	async def fake_render(*args):
+		fake_render.args = args
+
+	monkeypatch.setattr(level2, "prepare_level2_analysis", fake_prepare)
+	monkeypatch.setattr(level2, "render_level2_pdf", fake_render)
+
+	await level2.start_level2_analysis(
+		{"vehicle": {"make": "Subaru", "model": "Forester"}},
+		[listing],
+		"unused.json",
+	)
+
+	assert fake_render.args[3] == []
+	assert fake_render.args[4] == []
+	assert fake_render.args[5] == [
+		(listing, "Complete KBB pricing is unavailable for this configuration.")
+	]
+
+
+async def test_level2_records_missing_price_separately_from_kbb_mapping(monkeypatch):
+	missing_price = {"id": "no-price", "vin": "VIN4", "title": "No price"}
+	unmapped = {
+		"id": "unmapped",
+		"vin": "VIN5",
+		"title": "Unmapped trim",
+		"price": 26_000,
+	}
+	ctx = AnalysisContext(make="Subaru", model="Forester")
+	ctx.skipped_listings = [missing_price, unmapped]
+
+	async def fake_prepare(*_args, **_kwargs):
+		return ctx
+
+	async def fake_render(*args):
+		fake_render.args = args
+
+	monkeypatch.setattr(level2, "prepare_level2_analysis", fake_prepare)
+	monkeypatch.setattr(level2, "render_level2_pdf", fake_render)
+
+	await level2.start_level2_analysis(
+		{"vehicle": {"make": "Subaru", "model": "Forester"}},
+		[missing_price, unmapped],
+		"unused.json",
+	)
+
+	assert fake_render.args[5] == [
+		(missing_price, "Listing price is unavailable."),
+		(unmapped, "The listing trim could not be mapped to compatible KBB pricing."),
+	]
+
+
 def test_level2_bins_retain_unfavorable_complete_ratings():
 	ratings = [
 		({"id": "poor", "price": 20000}, "Poor", 2, []),

--- a/tests/unit/test_level2_eligibility.py
+++ b/tests/unit/test_level2_eligibility.py
@@ -176,3 +176,4 @@ def test_level2_template_keeps_jinja_out_of_inline_css():
 	assert "style=" not in template
 	assert "data-left-pct=" in template
 	assert "data-width-pct=" in template
+	assert "data-height-pct=" in template

--- a/tests/unit/test_level2_eligibility.py
+++ b/tests/unit/test_level2_eligibility.py
@@ -176,16 +176,16 @@ def test_level2_template_keeps_jinja_out_of_inline_css():
 	assert "style=" not in template
 	assert "data-left-pct=" in template
 	assert "data-width-pct=" in template
-	assert "data-bottom-pct=" in template
+	assert "class=\"deal-score\"" in template
 
 
-def test_level2_bins_sort_by_within_bin_strength():
+def test_level2_bins_sort_by_global_deal_score():
 	ratings = [
-		({"price": 20000}, "Fair", 0, [], {"deal_strength": 20}),
-		({"price": 21000}, "Fair", 1, [], {"deal_strength": 80}),
-		({"price": 19000}, "Fair", 0, [], {"deal_strength": 50}),
+		({"price": 20000}, "Fair", 0, [], {"deal_score": 20}),
+		({"price": 21000}, "Fair", 1, [], {"deal_score": 80}),
+		({"price": 19000}, "Fair", 0, [], {"deal_score": 50}),
 	]
 
 	bins = build_level2_bins(ratings)
 
-	assert [rating[4]["deal_strength"] for rating in bins["Fair"]] == [80, 50, 20]
+	assert [rating[4]["deal_score"] for rating in bins["Fair"]] == [80, 50, 20]

--- a/tests/unit/test_level2_eligibility.py
+++ b/tests/unit/test_level2_eligibility.py
@@ -168,3 +168,11 @@ def test_level2_branding_and_dealer_location_helpers():
 	assert logo_data_uri(Path("img/deallens-logo.svg")).startswith(
 		"data:image/svg+xml;base64,"
 	)
+
+
+def test_level2_template_keeps_jinja_out_of_inline_css():
+	template = Path("templates/level2.html").read_text(encoding="utf-8")
+
+	assert "style=" not in template
+	assert "data-left-pct=" in template
+	assert "data-width-pct=" in template

--- a/tests/unit/test_level2_eligibility.py
+++ b/tests/unit/test_level2_eligibility.py
@@ -71,14 +71,14 @@ def test_level2_bins_retain_unfavorable_complete_ratings():
 	ratings = [
 		({"id": "poor", "price": 20000}, "Poor", 2, []),
 		({"id": "bad", "price": 21000}, "Bad", 3, []),
-		({"id": "suspicious", "price": 10000}, "Suspicious", 7, []),
+		({"id": "great", "price": 10000}, "Great", 7, []),
 	]
 
 	bins = build_level2_bins(ratings)
 
 	assert bins["Poor"] == [ratings[0]]
 	assert bins["Bad"] == [ratings[1]]
-	assert bins["Suspicious"] == [ratings[2]]
+	assert bins["Great"] == [ratings[2]]
 
 
 def test_report_summary_accepts_single_condition_string():
@@ -95,7 +95,7 @@ def test_report_summarizes_unevaluated_reasons_without_listing_rows():
 		"level2.html"
 	)
 	empty_bins = {
-		name: [] for name in ("Great", "Good", "Fair", "Poor", "Bad", "Suspicious")
+		name: [] for name in ("Great", "Good", "Fair", "Poor", "Bad")
 	}
 	html = template.render(
 		make="Subaru",
@@ -114,7 +114,6 @@ def test_report_summarizes_unevaluated_reasons_without_listing_rows():
 		fair_bin=[],
 		poor_count=0,
 		bad_count=0,
-		sus_count=0,
 		all_images={},
 	)
 
@@ -180,6 +179,27 @@ def test_price_assessment_explains_percent_from_fair_midpoint():
 	level2._price_assessment(lc, narrative)
 
 	assert "Listing price is 1.9% above the fair-price midpoint." in narrative
+
+
+def test_price_below_displayed_great_range_remains_great_and_caps_marker():
+	lc = ListingContext(
+		listing_id="one",
+		listing={"price": 24000},
+		pricing=PricingAnchors(
+			fpp_natl=26000,
+			fpp_local=25000,
+			fmv=24000,
+			fmr_high=28000,
+		),
+	)
+
+	inside_great = level2._price_assessment(lc, [])
+	lc.listing["price"] = 21999
+	below_great = level2._price_assessment(lc, [])
+
+	assert inside_great is not None and inside_great[0] == "Great"
+	assert below_great is not None and below_great[0] == "Great"
+	assert below_great[4]["marker_pct"] == 0
 
 
 def test_level2_branding_and_dealer_location_helpers():

--- a/tests/unit/test_level2_scoring.py
+++ b/tests/unit/test_level2_scoring.py
@@ -1,11 +1,15 @@
+import pytest
+
 from analysis.scoring import (
 	deal_score_from_position,
 	calculate_deal_score,
 	deal_rating_from_score,
 	risk_penalty,
 	get_structure_score,
+	format_deal_score_narrative,
+	score_warranty_status,
 )
-from utils.models import StructuralStatus
+from utils.models import CarfaxData, StructuralStatus
 
 
 def test_favorable_evidence_crosses_nearby_good_to_great_boundary():
@@ -66,6 +70,10 @@ def test_risk_penalty_accelerates_as_risk_increases():
 	assert risk_penalty(10) == 100
 
 
+def test_adverse_mileage_risk_subtracts_from_deal_score():
+	assert calculate_deal_score(60, 4) < calculate_deal_score(60, 0)
+
+
 def test_zero_score_requires_bottom_price_and_maximum_risk():
 	assert calculate_deal_score(0, 0) == 10
 	assert calculate_deal_score(0, 4) > 0
@@ -79,3 +87,34 @@ def test_rating_is_derived_from_continuous_score():
 	assert deal_rating_from_score(40) == "Fair"
 	assert deal_rating_from_score(20) == "Poor"
 	assert deal_rating_from_score(19.9) == "Bad"
+
+
+def test_zero_score_components_use_plain_language():
+	narrative = format_deal_score_narrative(50, 50, 0, 0)
+
+	assert "no risk was identified" in narrative
+	assert "there is no favorable evidence" in narrative
+	assert "0.0/10" not in narrative
+	assert "0 points" not in narrative
+	assert "less than 1 point" in format_deal_score_narrative(50, 50, 0, 0.4)
+	assert "adds 1 point." in format_deal_score_narrative(50, 50, 0, 1.2)
+
+
+def test_warranty_bonus_uses_limiting_mileage_at_typical_use():
+	carfax = CarfaxData(
+		summary={},
+		accident_damage={},
+		reliability_section={},
+		additional_history={
+			"Structural Damage": "No structural damage reported to CARFAX.",
+			"Basic Warranty": "Original warranty estimated to have 5 months or 687 miles remaining.",
+		},
+		ownership_history={},
+		detailed_history=[],
+	)
+	narrative = []
+
+	result = score_warranty_status(carfax, {"coverages": []}, narrative)
+
+	assert result == pytest.approx(-0.0916, abs=0.001)
+	assert "about 0.5 months" in narrative[-1]

--- a/tests/unit/test_level2_scoring.py
+++ b/tests/unit/test_level2_scoring.py
@@ -42,10 +42,6 @@ def test_favorable_evidence_does_not_rescue_price_far_into_bad_bin():
 	assert deal_rating_from_score(score) == "Bad"
 
 
-def test_suspicious_price_handling_remains_ambiguous():
-	assert deal_score_from_position(50, "Suspicious") is None
-
-
 def test_possible_structure_wording_does_not_claim_confirmed_damage():
 	narrative = []
 
@@ -55,10 +51,10 @@ def test_possible_structure_wording_does_not_claim_confirmed_damage():
 
 
 def test_deal_score_uses_the_full_price_scale():
-	assert deal_score_from_position(9, "Great") == 91
-	assert deal_score_from_position(42, "Fair") == 58
-	assert deal_score_from_position(88, "Bad") == 12
-	assert deal_score_from_position(50, "Suspicious") is None
+	assert deal_score_from_position(9) == 91
+	assert deal_score_from_position(42) == 58
+	assert deal_score_from_position(88) == 12
+	assert deal_score_from_position(-10) == 100
 
 
 def test_risk_penalty_accelerates_as_risk_increases():

--- a/tests/unit/test_level2_scoring.py
+++ b/tests/unit/test_level2_scoring.py
@@ -3,6 +3,7 @@ import pytest
 from analysis.scoring import (
 	deal_score_from_position,
 	calculate_deal_score,
+	calculate_deal_score_result,
 	deal_rating_from_score,
 	risk_penalty,
 	get_structure_score,
@@ -90,15 +91,31 @@ def test_rating_is_derived_from_continuous_score():
 	assert deal_rating_from_score(19.9) == "Bad"
 
 
+def test_score_result_decouples_calculation_from_explanation():
+	result = calculate_deal_score_result(62, 1, 0)
+
+	assert result.price_score == 62
+	assert result.risk_score == 1
+	assert result.risk_penalty > 0
+	assert result.favorable_bonus == 0
+	assert result.final_score == 59
+	assert result.rating == "Fair"
+	assert format_deal_score_narrative(result).startswith("Deal Score is 59%")
+
+
 def test_zero_score_components_use_plain_language():
-	narrative = format_deal_score_narrative(50, 50, 0, 0)
+	narrative = format_deal_score_narrative(calculate_deal_score_result(50, 0, 0))
 
 	assert "no risk was identified" in narrative
 	assert "there is no favorable evidence" in narrative
 	assert "0.0/10" not in narrative
 	assert "0 points" not in narrative
-	assert "less than 1 point" in format_deal_score_narrative(50, 50, 0, 0.4)
-	assert "adds 1 point." in format_deal_score_narrative(50, 50, 0, 1.2)
+	assert "less than 1 point" in format_deal_score_narrative(
+		calculate_deal_score_result(50, 0, 0.05)
+	)
+	assert "adds 1 point." in format_deal_score_narrative(
+		calculate_deal_score_result(50, 0, 0.2)
+	)
 
 
 def test_warranty_bonus_uses_limiting_mileage_at_typical_use():

--- a/tests/unit/test_level2_scoring.py
+++ b/tests/unit/test_level2_scoring.py
@@ -1,6 +1,7 @@
 from analysis.scoring import (
 	adjust_deal_for_evidence,
 	adjust_deal_for_risk,
+	deal_score_from_position,
 	deal_strength_within_bin,
 	get_structure_score,
 )
@@ -78,3 +79,10 @@ def test_deal_strength_shows_position_within_assigned_bin():
 	assert deal_strength_within_bin("Fair", 27254, SPORT_CUTOFFS) == 50
 	assert deal_strength_within_bin("Bad", 30241, SPORT_CUTOFFS) == 0
 	assert deal_strength_within_bin("Suspicious", 20000, SPORT_CUTOFFS) is None
+
+
+def test_deal_score_uses_the_full_price_scale():
+	assert deal_score_from_position(9, "Great") == 91
+	assert deal_score_from_position(42, "Fair") == 58
+	assert deal_score_from_position(88, "Bad") == 12
+	assert deal_score_from_position(50, "Suspicious") is None

--- a/tests/unit/test_level2_scoring.py
+++ b/tests/unit/test_level2_scoring.py
@@ -1,41 +1,72 @@
-from analysis.scoring import adjust_deal_for_risk, supports_deal_upgrade
+from analysis.scoring import (
+	adjust_deal_for_evidence,
+	adjust_deal_for_risk,
+	get_structure_score,
+)
+from utils.models import StructuralStatus
 
 
-def test_zero_risk_upgrades_price_rating_one_bin():
+SPORT_CUTOFFS = (26153, 26887, 27621, 28355)
+
+
+def test_favorable_evidence_crosses_nearby_good_to_great_boundary():
 	narrative = []
 
-	assert adjust_deal_for_risk(
-		"Good", 0, narrative, favorable_evidence=True
-	) == "Great"
-	assert "upgraded to Great" in narrative[-1]
-	assert adjust_deal_for_risk("Poor", 0, favorable_evidence=True) == "Fair"
+	result = adjust_deal_for_evidence(
+		"Good", -2.5, 26194, 433, (26187, 27053, 27919, 28785), narrative
+	)
+
+	assert result == "Great"
+	assert "from Good to Great" in narrative[-1]
 
 
-def test_zero_risk_cannot_upgrade_beyond_great():
-	assert adjust_deal_for_risk("Great", 0, favorable_evidence=True) == "Great"
+def test_adverse_evidence_crosses_nearby_good_to_fair_boundary():
+	result = adjust_deal_for_evidence(
+		"Good", 1.019789174705252, 26816, 367, SPORT_CUTOFFS
+	)
+
+	assert result == "Fair"
 
 
-def test_neutral_zero_risk_does_not_upgrade_without_favorable_evidence():
-	assert adjust_deal_for_risk("Good", 0) == "Good"
+def test_marginal_warranty_does_not_move_centered_fair_price():
+	result = adjust_deal_for_evidence(
+		"Fair", -1.0, 26142, 1100, (23130, 25330, 27530, 29730)
+	)
+
+	assert result == "Fair"
 
 
-def test_low_nonzero_risk_remains_neutral():
-	assert adjust_deal_for_risk("Good", 1) == "Good"
-	assert adjust_deal_for_risk("Good", 2) == "Good"
+def test_strong_evidence_barely_crosses_poor_to_fair_boundary():
+	result = adjust_deal_for_evidence(
+		"Poor", -2.5, 28170, 367, SPORT_CUTOFFS
+	)
+
+	assert result == "Fair"
 
 
-def test_existing_risk_downgrades_are_preserved():
+def test_favorable_evidence_does_not_rescue_price_far_into_bad_bin():
+	result = adjust_deal_for_evidence(
+		"Bad", -2.0, 30241, 367, SPORT_CUTOFFS
+	)
+
+	assert result == "Bad"
+
+
+def test_existing_legacy_risk_downgrades_are_preserved():
 	assert adjust_deal_for_risk("Good", 3) == "Fair"
 	assert adjust_deal_for_risk("Good", 5) == "Poor"
 	assert adjust_deal_for_risk("Good", 7) == "Bad"
 
 
-def test_suspicious_price_handling_is_not_upgraded():
-	assert adjust_deal_for_risk("Suspicious", 0) == "Suspicious"
+def test_suspicious_price_handling_remains_ambiguous():
+	assert adjust_deal_for_evidence(
+		"Suspicious", -2.5, 20000, 500, SPORT_CUTOFFS
+	) == "Suspicious"
 
 
-def test_deal_upgrade_requires_substantial_favorable_evidence():
-	assert supports_deal_upgrade(-2.5) is True
-	assert supports_deal_upgrade(-2.0) is True
-	assert supports_deal_upgrade(-1.0) is False
-	assert supports_deal_upgrade(0.0) is False
+def test_possible_structure_wording_does_not_claim_confirmed_damage():
+	narrative = []
+
+	get_structure_score(StructuralStatus.POSSIBLE, 1.0, narrative)
+
+	assert "does not confirm structural damage" in narrative[-1]

--- a/tests/unit/test_level2_scoring.py
+++ b/tests/unit/test_level2_scoring.py
@@ -1,0 +1,41 @@
+from analysis.scoring import adjust_deal_for_risk, supports_deal_upgrade
+
+
+def test_zero_risk_upgrades_price_rating_one_bin():
+	narrative = []
+
+	assert adjust_deal_for_risk(
+		"Good", 0, narrative, favorable_evidence=True
+	) == "Great"
+	assert "upgraded to Great" in narrative[-1]
+	assert adjust_deal_for_risk("Poor", 0, favorable_evidence=True) == "Fair"
+
+
+def test_zero_risk_cannot_upgrade_beyond_great():
+	assert adjust_deal_for_risk("Great", 0, favorable_evidence=True) == "Great"
+
+
+def test_neutral_zero_risk_does_not_upgrade_without_favorable_evidence():
+	assert adjust_deal_for_risk("Good", 0) == "Good"
+
+
+def test_low_nonzero_risk_remains_neutral():
+	assert adjust_deal_for_risk("Good", 1) == "Good"
+	assert adjust_deal_for_risk("Good", 2) == "Good"
+
+
+def test_existing_risk_downgrades_are_preserved():
+	assert adjust_deal_for_risk("Good", 3) == "Fair"
+	assert adjust_deal_for_risk("Good", 5) == "Poor"
+	assert adjust_deal_for_risk("Good", 7) == "Bad"
+
+
+def test_suspicious_price_handling_is_not_upgraded():
+	assert adjust_deal_for_risk("Suspicious", 0) == "Suspicious"
+
+
+def test_deal_upgrade_requires_substantial_favorable_evidence():
+	assert supports_deal_upgrade(-2.5) is True
+	assert supports_deal_upgrade(-2.0) is True
+	assert supports_deal_upgrade(-1.0) is False
+	assert supports_deal_upgrade(0.0) is False

--- a/tests/unit/test_level2_scoring.py
+++ b/tests/unit/test_level2_scoring.py
@@ -74,6 +74,11 @@ def test_adverse_mileage_risk_subtracts_from_deal_score():
 	assert calculate_deal_score(60, 4) < calculate_deal_score(60, 0)
 
 
+def test_meaningful_risk_negates_favorable_evidence():
+	assert calculate_deal_score(60, 4, 3) == calculate_deal_score(60, 4, 0)
+	assert calculate_deal_score(60, 3, 3) > calculate_deal_score(60, 3, 0)
+
+
 def test_zero_score_requires_bottom_price_and_maximum_risk():
 	assert calculate_deal_score(0, 0) == 10
 	assert calculate_deal_score(0, 4) > 0

--- a/tests/unit/test_level2_scoring.py
+++ b/tests/unit/test_level2_scoring.py
@@ -1,69 +1,45 @@
 from analysis.scoring import (
-	adjust_deal_for_evidence,
-	adjust_deal_for_risk,
 	deal_score_from_position,
-	deal_strength_within_bin,
+	calculate_deal_score,
+	deal_rating_from_score,
+	risk_penalty,
 	get_structure_score,
 )
 from utils.models import StructuralStatus
 
 
-SPORT_CUTOFFS = (26153, 26887, 27621, 28355)
-
-
 def test_favorable_evidence_crosses_nearby_good_to_great_boundary():
-	narrative = []
+	score = calculate_deal_score(80, 0, 2.5)
 
-	result = adjust_deal_for_evidence(
-		"Good", -2.5, 26194, 433, (26187, 27053, 27919, 28785), narrative
-	)
-
-	assert result == "Great"
-	assert "from Good to Great" in narrative[-1]
+	assert deal_rating_from_score(score) == "Great"
 
 
 def test_adverse_evidence_crosses_nearby_good_to_fair_boundary():
-	result = adjust_deal_for_evidence(
-		"Good", 1.019789174705252, 26816, 367, SPORT_CUTOFFS
-	)
+	score = calculate_deal_score(62, 1.019789174705252)
 
-	assert result == "Fair"
+	assert deal_rating_from_score(score) == "Fair"
 
 
 def test_marginal_warranty_does_not_move_centered_fair_price():
-	result = adjust_deal_for_evidence(
-		"Fair", -1.0, 26142, 1100, (23130, 25330, 27530, 29730)
-	)
+	score = calculate_deal_score(53, 0, 1.0)
 
-	assert result == "Fair"
+	assert deal_rating_from_score(score) == "Fair"
 
 
 def test_strong_evidence_barely_crosses_poor_to_fair_boundary():
-	result = adjust_deal_for_evidence(
-		"Poor", -2.5, 28170, 367, SPORT_CUTOFFS
-	)
+	score = calculate_deal_score(25, 0, 2.5)
 
-	assert result == "Fair"
+	assert deal_rating_from_score(score) == "Fair"
 
 
 def test_favorable_evidence_does_not_rescue_price_far_into_bad_bin():
-	result = adjust_deal_for_evidence(
-		"Bad", -2.0, 30241, 367, SPORT_CUTOFFS
-	)
+	score = calculate_deal_score(0, 0, 2.0)
 
-	assert result == "Bad"
-
-
-def test_existing_legacy_risk_downgrades_are_preserved():
-	assert adjust_deal_for_risk("Good", 3) == "Fair"
-	assert adjust_deal_for_risk("Good", 5) == "Poor"
-	assert adjust_deal_for_risk("Good", 7) == "Bad"
+	assert deal_rating_from_score(score) == "Bad"
 
 
 def test_suspicious_price_handling_remains_ambiguous():
-	assert adjust_deal_for_evidence(
-		"Suspicious", -2.5, 20000, 500, SPORT_CUTOFFS
-	) == "Suspicious"
+	assert deal_score_from_position(50, "Suspicious") is None
 
 
 def test_possible_structure_wording_does_not_claim_confirmed_damage():
@@ -74,15 +50,32 @@ def test_possible_structure_wording_does_not_claim_confirmed_damage():
 	assert "does not confirm structural damage" in narrative[-1]
 
 
-def test_deal_strength_shows_position_within_assigned_bin():
-	assert deal_strength_within_bin("Fair", 27620, SPORT_CUTOFFS) < 1
-	assert deal_strength_within_bin("Fair", 27254, SPORT_CUTOFFS) == 50
-	assert deal_strength_within_bin("Bad", 30241, SPORT_CUTOFFS) == 0
-	assert deal_strength_within_bin("Suspicious", 20000, SPORT_CUTOFFS) is None
-
-
 def test_deal_score_uses_the_full_price_scale():
 	assert deal_score_from_position(9, "Great") == 91
 	assert deal_score_from_position(42, "Fair") == 58
 	assert deal_score_from_position(88, "Bad") == 12
 	assert deal_score_from_position(50, "Suspicious") is None
+
+
+def test_risk_penalty_accelerates_as_risk_increases():
+	low_step = risk_penalty(2) - risk_penalty(1)
+	moderate_step = risk_penalty(5) - risk_penalty(4)
+	high_step = risk_penalty(9) - risk_penalty(8)
+
+	assert 0 < low_step < moderate_step < high_step
+	assert risk_penalty(10) == 100
+
+
+def test_zero_score_requires_bottom_price_and_maximum_risk():
+	assert calculate_deal_score(0, 0) == 10
+	assert calculate_deal_score(0, 4) > 0
+	assert calculate_deal_score(0, 10) == 0
+	assert calculate_deal_score(100, 10) > 0
+
+
+def test_rating_is_derived_from_continuous_score():
+	assert deal_rating_from_score(80) == "Great"
+	assert deal_rating_from_score(60) == "Good"
+	assert deal_rating_from_score(40) == "Fair"
+	assert deal_rating_from_score(20) == "Poor"
+	assert deal_rating_from_score(19.9) == "Bad"

--- a/tests/unit/test_level2_scoring.py
+++ b/tests/unit/test_level2_scoring.py
@@ -119,3 +119,39 @@ def test_warranty_bonus_uses_limiting_mileage_at_typical_use():
 
 	assert result == pytest.approx(-0.0916, abs=0.001)
 	assert "about 0.5 months" in narrative[-1]
+
+
+def test_missing_warranty_information_is_neutral():
+	carfax = CarfaxData(
+		summary={},
+		accident_damage={},
+		reliability_section={},
+		additional_history={},
+		ownership_history={},
+		detailed_history=[],
+	)
+	narrative = []
+
+	result = score_warranty_status(carfax, {"coverages": []}, narrative)
+
+	assert result == 0
+	assert narrative == [
+		"Basic warranty information is unavailable; it does not affect scoring."
+	]
+
+
+def test_explicitly_expired_warranty_remains_neutral_but_known():
+	carfax = CarfaxData(
+		summary={},
+		accident_damage={},
+		reliability_section={},
+		additional_history={"Basic Warranty": "Original warranty has expired."},
+		ownership_history={},
+		detailed_history=[],
+	)
+	narrative = []
+
+	result = score_warranty_status(carfax, {"coverages": []}, narrative)
+
+	assert result == 0
+	assert narrative == ["The basic warranty on this vehicle has expired."]

--- a/tests/unit/test_level2_scoring.py
+++ b/tests/unit/test_level2_scoring.py
@@ -1,6 +1,7 @@
 from analysis.scoring import (
 	adjust_deal_for_evidence,
 	adjust_deal_for_risk,
+	deal_strength_within_bin,
 	get_structure_score,
 )
 from utils.models import StructuralStatus
@@ -70,3 +71,10 @@ def test_possible_structure_wording_does_not_claim_confirmed_damage():
 	get_structure_score(StructuralStatus.POSSIBLE, 1.0, narrative)
 
 	assert "does not confirm structural damage" in narrative[-1]
+
+
+def test_deal_strength_shows_position_within_assigned_bin():
+	assert deal_strength_within_bin("Fair", 27620, SPORT_CUTOFFS) < 1
+	assert deal_strength_within_bin("Fair", 27254, SPORT_CUTOFFS) == 50
+	assert deal_strength_within_bin("Bad", 30241, SPORT_CUTOFFS) == 0
+	assert deal_strength_within_bin("Suspicious", 20000, SPORT_CUTOFFS) is None

--- a/tests/unit/test_level2_scraper_integration.py
+++ b/tests/unit/test_level2_scraper_integration.py
@@ -1,0 +1,124 @@
+from argparse import Namespace
+from pathlib import Path
+
+from analysis.analysis_utils import check_missing_docs
+from visor_api import Level2Collection, Level2Exclusion, Level2ListingRecord
+from visor_scraper.scraper import apply_level2_collection_metadata, scrape
+
+
+def collection():
+	return Level2Collection(
+		listings=(
+			Level2ListingRecord(
+				listing_id="listing-1",
+				vin="TESTVIN1",
+				listing={
+					"id": "listing-1",
+					"vin": "TESTVIN1",
+					"warnings": [{
+						"field": "warranty",
+						"code": "missing_data",
+						"message": "Warranty is unavailable.",
+					}],
+				},
+				search_record={"id": "listing-1", "vin": "TESTVIN1"},
+				detail_record={"id": "listing-1", "vin": "TESTVIN1"},
+			),
+			Level2ListingRecord(
+				listing_id="listing-2",
+				vin="TESTVIN2",
+				listing={"id": "listing-2", "vin": "TESTVIN2", "warnings": []},
+				search_record={"id": "listing-2", "vin": "TESTVIN2"},
+				detail_record=None,
+				detail_error="Visor API read timeout",
+			),
+		),
+		exclusions=(
+			Level2Exclusion(
+				index=2,
+				reason="missing_stable_listing_id",
+				vin="TESTVIN3",
+			),
+		),
+		request_params={
+			"make": ["Subaru"],
+			"model": ["Forester"],
+			"include": "options,price_history",
+		},
+		retrieved_at="2026-07-21T00:00:00+00:00",
+		raw_search_response={
+			"data": [],
+			"pagination": {
+				"limit": 10,
+				"offset": 0,
+				"total": 125,
+				"next_offset": 10,
+			},
+			"meta": {},
+		},
+	)
+
+
+def test_collection_metadata_preserves_api_provenance_and_failures():
+	metadata = {
+		"site_info": {},
+		"runtime": {},
+		"warnings": [],
+	}
+
+	apply_level2_collection_metadata(metadata, collection(), cache_used=True)
+
+	assert metadata["site_info"]["total_for_sale"] == 125
+	assert metadata["runtime"]["source"] == "visor_api"
+	assert metadata["sources"]["visor_api"]["listings"] == {
+		"endpoint": "/v1/listings",
+		"query": {
+			"make": ["Subaru"],
+			"model": ["Forester"],
+			"include": "options,price_history",
+		},
+		"retrieved_at": "2026-07-21T00:00:00+00:00",
+		"cache_used": True,
+	}
+	assert metadata["sources"]["visor_api"]["details"]["requested"] == 2
+	assert metadata["sources"]["visor_api"]["details"]["retrieved"] == 1
+	assert metadata["warnings"][0]["listing_id"] == "listing-1"
+	assert metadata["warnings"][1]["code"] == "excluded_api_record"
+	assert metadata["warnings"][1]["vin"] == "TESTVIN3"
+
+
+async def test_level2_scrape_routes_to_api_collection(monkeypatch):
+	calls = []
+
+	async def fake_collect(args):
+		calls.append(args)
+
+	monkeypatch.setattr(
+		"visor_scraper.scraper.collect_and_run_level2_api", fake_collect
+	)
+	args = Namespace(level1=False, level2=True, level3=False)
+
+	await scrape(args)
+
+	assert calls == [args]
+
+
+def test_missing_document_check_ignores_null_and_legacy_sentinels(monkeypatch):
+	downloads = []
+	monkeypatch.setattr(
+		"analysis.analysis_utils.get_vehicle_dir",
+		lambda listing: Path("missing-vehicle-directory"),
+	)
+	monkeypatch.setattr(
+		"analysis.analysis_utils.download_report_pdfs",
+		lambda listings: downloads.extend(listings),
+	)
+	listings = [
+		{"vin": "NULL", "additional_docs": {"carfax_url": None}},
+		{"vin": "LEGACY", "additional_docs": {"carfax_url": "Unavailable"}},
+		{"vin": "URL", "additional_docs": {"carfax_url": "https://example.invalid/report"}},
+	]
+
+	check_missing_docs(listings)
+
+	assert [listing["vin"] for listing in downloads] == ["URL"]

--- a/tests/unit/test_level2_service.py
+++ b/tests/unit/test_level2_service.py
@@ -1,0 +1,167 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from visor_api import (
+	LEVEL2_SEARCH_EXPANSIONS,
+	LEVEL2_SEARCH_FIELDS,
+	VisorListingQuery,
+	collect_level2_listings,
+)
+
+
+class FakeLevel2Client:
+	def __init__(self, rows, details=None, detail_errors=None):
+		self.rows = rows
+		self.details = details or {}
+		self.detail_errors = detail_errors or {}
+		self.search_calls = []
+		self.detail_calls = []
+
+	def filter_all_listings(self, params=None, *, max_listings=50):
+		self.search_calls.append((dict(params or {}), max_listings))
+		return {
+			"data": self.rows,
+			"pagination": {
+				"limit": max_listings,
+				"offset": 0,
+				"total": len(self.rows) if isinstance(self.rows, list) else 0,
+				"next_offset": None,
+			},
+			"meta": {},
+		}
+
+	def get_listing(self, listing_id, params=None):
+		self.detail_calls.append((listing_id, params))
+		if listing_id in self.detail_errors:
+			raise self.detail_errors[listing_id]
+		return {"data": self.details.get(listing_id, {"id": listing_id})}
+
+
+def query(**overrides):
+	options = {
+		"make": "Subaru",
+		"model": "Crosstrek",
+		"year": (2024, 2025, 2026),
+		"max_mileage": 75_000,
+		"sort": "lowest price",
+	}
+	options.update(overrides)
+	return VisorListingQuery.from_options(options)
+
+
+def search_row(listing_id="listing-1", vin="TESTVIN1"):
+	return {
+		"id": listing_id,
+		"vin": vin,
+		"year": 2024,
+		"make": "Subaru",
+		"model": "Crosstrek",
+		"trim": "Premium",
+		"price": 25_000,
+		"miles": 10_000,
+		"inventory_type": "certified",
+		"options": [{"code": "OP1", "name": "Package", "msrp": 500}],
+		"price_history": [],
+	}
+
+
+def detail_row(listing_id="listing-1"):
+	return {
+		"id": listing_id,
+		"vin": "TESTVIN1",
+		"dealer": {
+			"dealer_id": "dealer-1",
+			"name": "Example Subaru",
+			"city": "Denver",
+			"state": "CO",
+			"postal_code": "80202",
+			"phone": "(000) 000-0000",
+		},
+		"vehicle": {"build": {"version": "Premium AWD"}},
+	}
+
+
+def test_collection_uses_enriched_search_and_sequential_standard_details():
+	client = FakeLevel2Client(
+		[search_row(), search_row("listing-2", "TESTVIN2")],
+		{"listing-1": detail_row(), "listing-2": detail_row("listing-2")},
+	)
+
+	result = collect_level2_listings(
+		client,
+		query(),
+		max_listings=100,
+		clock=lambda: datetime(2026, 7, 21, tzinfo=timezone.utc),
+	)
+
+	params, maximum = client.search_calls[0]
+	assert maximum == 100
+	assert params["fields"] == LEVEL2_SEARCH_FIELDS
+	assert params["include"] == LEVEL2_SEARCH_EXPANSIONS
+	assert params["sort"] == "price"
+	assert "inventory_type" not in params
+	assert client.detail_calls == [("listing-1", None), ("listing-2", None)]
+	assert [item.listing_id for item in result.listings] == ["listing-1", "listing-2"]
+	assert result.listings[0].vin == "TESTVIN1"
+	assert result.listings[0].listing["seller"]["phone"] == "(000) 000-0000"
+	assert result.retrieved_at == "2026-07-21T00:00:00+00:00"
+	assert result.raw_search_response["data"][0]["options"][0]["code"] == "OP1"
+
+
+def test_collection_preserves_search_listing_when_detail_fails():
+	client = FakeLevel2Client(
+		[search_row()],
+		detail_errors={"listing-1": RuntimeError("detail unavailable")},
+	)
+
+	result = collect_level2_listings(client, query())
+	record = result.listings[0]
+
+	assert record.detail_record is None
+	assert record.detail_error == "RuntimeError"
+	assert record.listing["price"] == 25_000
+	assert record.listing["provenance"]["detail"]["reason"] == "source_error"
+	assert record.listing["warnings"][-1]["field"] == "detail"
+	assert result.exclusions == ()
+
+
+def test_collection_records_malformed_missing_and_duplicate_rows():
+	client = FakeLevel2Client([
+		"not-an-object",
+		{"vin": "NOID"},
+		search_row(),
+		search_row(),
+	])
+
+	result = collect_level2_listings(client, query())
+
+	assert len(result.listings) == 1
+	assert [item.reason for item in result.exclusions] == [
+		"search_record_not_object",
+		"missing_stable_listing_id",
+		"duplicate_stable_listing_id",
+	]
+	assert client.detail_calls == [("listing-1", None)]
+
+
+def test_collection_rejects_non_array_search_data():
+	client = FakeLevel2Client([])
+	client.rows = None
+
+	with pytest.raises(ValueError, match="must be an array"):
+		collect_level2_listings(client, query())
+
+
+def test_collection_rejects_unsupported_and_naive_clock():
+	client = FakeLevel2Client([])
+	unsupported = query(unknown_filter="value")
+	with pytest.raises(ValueError, match="unsupported query options"):
+		collect_level2_listings(client, unsupported)
+
+	with pytest.raises(ValueError, match="aware datetime"):
+		collect_level2_listings(
+			client,
+			query(),
+			clock=lambda: datetime(2026, 7, 21),
+		)

--- a/tests/unit/test_visor_adapter.py
+++ b/tests/unit/test_visor_adapter.py
@@ -87,6 +87,82 @@ def test_detail_values_are_preferred_but_nulls_fall_back_to_search():
 	assert listing["year"] == 2025
 
 
+def test_search_only_and_search_plus_detail_records_keep_stable_identity():
+	search = {
+		"id": "listing-1",
+		"vin": "TESTVIN1",
+		"year": 2024,
+		"make": "Subaru",
+		"model": "Forester",
+		"trim": "Premium",
+		"price": 25_000,
+		"miles": 10_000,
+	}
+	detail = {
+		"id": "listing-1",
+		"dealer": {"name": "Detail Dealer", "phone": "555-0100"},
+		"vehicle": {"build": {"version": "Premium AWD"}},
+	}
+
+	search_only = adapt_listing(search)
+	combined = adapt_listing(search, detail)
+
+	assert search_only["id"] == combined["id"] == "listing-1"
+	assert search_only["vin"] == combined["vin"] == "TESTVIN1"
+	assert search_only["price"] == combined["price"] == 25_000
+	assert search_only["mileage"] == combined["mileage"] == 10_000
+	assert search_only["seller"]["phone"] is None
+	assert combined["seller"]["phone"] == "555-0100"
+	assert search_only["specs"]["Trim Version"] is None
+	assert combined["specs"]["Trim Version"] == "Premium AWD"
+
+
+def test_missing_mileage_is_retained_as_unknown_with_warning():
+	listing = adapt_listing({
+		"id": "listing-1",
+		"vin": "TESTVIN1",
+		"year": 2024,
+		"make": "Subaru",
+		"model": "Forester",
+		"trim": "Premium",
+		"price": 25_000,
+	})
+
+	mileage_warning = next(
+		warning for warning in listing["warnings"]
+		if warning["field"] == "mileage"
+	)
+
+	assert listing["mileage"] is None
+	assert mileage_warning["code"] == "missing_data"
+
+
+def test_missing_api_warranty_and_documents_remain_explicitly_unavailable():
+	listing = adapt_listing({"id": "listing-1", "miles": 0})
+	normalized = normalize_listing(listing)
+
+	assert listing["warranty"] is None
+	assert listing["additional_docs"] == {
+		"carfax_url": None,
+		"autocheck_url": None,
+		"window_sticker_url": None,
+	}
+	assert normalized["warranty_info_present"] is None
+	assert normalized["coverages"] == []
+	assert normalized["report_present"] is None
+	assert normalized["window_sticker_present"] is None
+	for field in (
+		"warranty",
+		"additional_docs.carfax_url",
+		"additional_docs.autocheck_url",
+		"additional_docs.window_sticker_url",
+	):
+		assert listing["provenance"][field] == {
+			"kind": "unavailable",
+			"reason": "not_provided_by_api",
+		}
+
+
 def test_unknown_condition_and_unrequested_collections_remain_unavailable():
 	listing = adapt_listing({"id": "one", "inventory_type": "fleet"})
 

--- a/utils/download.py
+++ b/utils/download.py
@@ -760,7 +760,7 @@ async def download_files(
             cached_url = analysis_cache.get(vin, {}).get("carfax_url")
             cached_fee = analysis_cache.get(vin, {}).get("dealer_fee")
             cached_included = analysis_cache.get(vin, {}).get("dealer_fee_included")
-            if cached_url and url == "Unavailable":
+            if cached_url and (not url or url == "Unavailable"):
                 l.setdefault("additional_docs", {})["carfax_url"] = cached_url
             if cached_fee:
                 l.setdefault("seller", {})["dealer_fee"] = cached_fee

--- a/utils/download.py
+++ b/utils/download.py
@@ -280,7 +280,14 @@ async def download_images(req: APIRequestContext, listing: dict, folder: str) ->
         # temporary name before detecting extension
         tmp_path = os.path.join(img_dir, f"{idx}")
 
-        resp = await req.get(url)
+        try:
+            resp = await req.get(url)
+        except Exception as error:
+            print(
+                f"Skipped image {idx} for listing {listing.get('id')}: "
+                f"{type(error).__name__}"
+            )
+            continue
         if not resp.ok:
             continue
 

--- a/visor_api/__init__.py
+++ b/visor_api/__init__.py
@@ -27,6 +27,16 @@ from visor_api.level1_service import (
 	collect_level1_facets,
 )
 from visor_api.level1_cache import CachedLevel1FacetResult, cached_level1_facets
+from visor_api.level2_service import (
+	LEVEL2_SEARCH_EXPANSIONS,
+	LEVEL2_SEARCH_FIELDS,
+	Level2Collection,
+	Level2Exclusion,
+	Level2ListingRecord,
+	collect_level2_listings,
+	level2_search_params,
+)
+from visor_api.level2_cache import CachedLevel2Result, cached_level2_collection
 from visor_api.cache import CachedSearchResult, cached_listing_search
 from visor_api.models import (
 	APIModel,
@@ -77,6 +87,15 @@ __all__ = [
 	"collect_level1_facets",
 	"CachedLevel1FacetResult",
 	"cached_level1_facets",
+	"LEVEL2_SEARCH_EXPANSIONS",
+	"LEVEL2_SEARCH_FIELDS",
+	"Level2Collection",
+	"Level2Exclusion",
+	"Level2ListingRecord",
+	"collect_level2_listings",
+	"level2_search_params",
+	"CachedLevel2Result",
+	"cached_level2_collection",
 	"CachedSearchResult",
 	"cached_listing_search",
 	"APIModel",

--- a/visor_api/level2_cache.py
+++ b/visor_api/level2_cache.py
@@ -1,0 +1,123 @@
+"""Atomic local cache for complete Level 2 listing collections."""
+
+import hashlib
+import json
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from visor_api.level2_service import (
+	Level2Client,
+	Level2Collection,
+	collect_level2_listings,
+	level2_search_params,
+)
+from visor_api.query import VisorListingQuery
+
+
+LEVEL2_CACHE_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True, kw_only=True)
+class CachedLevel2Result:
+	collection: Level2Collection
+	cache_path: Path
+	cache_used: bool
+
+
+def cached_level2_collection(
+	client: Level2Client,
+	query: VisorListingQuery,
+	*,
+	cache_dir: str | Path,
+	max_listings: int = 100,
+	force: bool = False,
+	clock: Callable[[], datetime] | None = None,
+) -> CachedLevel2Result:
+	"""Return a Level 2 collection cached through the local calendar day."""
+	if query.unsupported:
+		raise ValueError(f"unsupported query options: {sorted(query.unsupported)}")
+	if max_listings < 0:
+		raise ValueError("max_listings must not be negative")
+	now = clock or (lambda: datetime.now(timezone.utc))
+	current = now()
+	cache_date = _local_date(current)
+	fingerprint = _fingerprint(query, max_listings)
+	cache_path = Path(cache_dir) / f"visor-level2-{fingerprint}.json"
+
+	if cache_path.is_file() and not force:
+		collection = _read_cache(cache_path, cache_date, fingerprint)
+		if collection is not None:
+			return CachedLevel2Result(
+				collection=collection,
+				cache_path=cache_path,
+				cache_used=True,
+			)
+
+	collection = collect_level2_listings(
+		client,
+		query,
+		max_listings=max_listings,
+		clock=lambda: current,
+	)
+	_write_cache(cache_path, {
+		"cache_schema": LEVEL2_CACHE_SCHEMA_VERSION,
+		"cache_date": cache_date,
+		"fingerprint": fingerprint,
+		"collection": collection.to_dict(),
+	})
+	return CachedLevel2Result(
+		collection=collection,
+		cache_path=cache_path,
+		cache_used=False,
+	)
+
+
+def _read_cache(
+	cache_path: Path,
+	cache_date: str,
+	fingerprint: str,
+) -> Level2Collection | None:
+	try:
+		envelope = json.loads(cache_path.read_text(encoding="utf-8"))
+		if (
+			envelope.get("cache_schema") != LEVEL2_CACHE_SCHEMA_VERSION
+			or envelope.get("cache_date") != cache_date
+			or envelope.get("fingerprint") != fingerprint
+		):
+			return None
+		collection = envelope.get("collection")
+		if not isinstance(collection, dict):
+			return None
+		return Level2Collection.from_dict(collection)
+	except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+		return None
+
+
+def _write_cache(cache_path: Path, envelope: dict[str, Any]) -> None:
+	cache_path.parent.mkdir(parents=True, exist_ok=True)
+	temporary_path = cache_path.with_suffix(".tmp")
+	temporary_path.write_text(
+		json.dumps(envelope, indent=2, ensure_ascii=False),
+		encoding="utf-8",
+	)
+	temporary_path.replace(cache_path)
+
+
+def _fingerprint(query: VisorListingQuery, max_listings: int) -> str:
+	payload = {
+		"endpoint": "/v1/listings",
+		"query": level2_search_params(query),
+		"max_listings": max_listings,
+	}
+	encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+	return hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:16]
+
+
+def _local_date(value: datetime) -> str:
+	if value.tzinfo is None or value.utcoffset() is None:
+		raise ValueError("Level 2 cache clock must return an aware datetime")
+	return value.astimezone().date().isoformat()

--- a/visor_api/level2_service.py
+++ b/visor_api/level2_service.py
@@ -1,0 +1,280 @@
+"""Collect enriched listing search data and standard detail for Level 2."""
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+from visor_api.adapter import adapt_listing
+from visor_api.client import QueryParams, VisorAPIError, VisorTimeoutError
+from visor_api.query import VisorListingQuery
+
+
+LEVEL2_SEARCH_FIELDS = (
+	"default,msrp,discount_from_msrp,days_on_market,photo_urls,features,"
+	"options_packages"
+)
+LEVEL2_SEARCH_EXPANSIONS = "options,price_history"
+
+
+class Level2Client(Protocol):
+	"""Client capabilities required by Level 2 collection."""
+
+	def filter_all_listings(
+		self,
+		params: QueryParams | None = None,
+		*,
+		max_listings: int = 50,
+	) -> dict[str, Any]: ...
+
+	def get_listing(
+		self,
+		listing_id: str,
+		params: QueryParams | None = None,
+	) -> dict[str, Any]: ...
+
+
+@dataclass(frozen=True, kw_only=True)
+class Level2ListingRecord:
+	"""One retained search record plus optional detail and adapted data."""
+
+	listing_id: str
+	vin: str | None
+	listing: dict[str, Any]
+	search_record: dict[str, Any]
+	detail_record: dict[str, Any] | None
+	detail_error: str | None = None
+
+	def to_dict(self) -> dict[str, Any]:
+		return {
+			"listing_id": self.listing_id,
+			"vin": self.vin,
+			"listing": self.listing,
+			"search_record": self.search_record,
+			"detail_record": self.detail_record,
+			"detail_error": self.detail_error,
+		}
+
+	@classmethod
+	def from_dict(cls, value: Mapping[str, Any]) -> "Level2ListingRecord":
+		listing_id = value.get("listing_id")
+		if not isinstance(listing_id, str) or not listing_id:
+			raise ValueError("cached Level 2 listing_id must be a non-empty string")
+		return cls(
+			listing_id=listing_id,
+			vin=_optional_string(value.get("vin")),
+			listing=_dictionary(value.get("listing"), "listing"),
+			search_record=_dictionary(value.get("search_record"), "search_record"),
+			detail_record=(
+				_dictionary(value.get("detail_record"), "detail_record")
+				if value.get("detail_record") is not None else None
+			),
+			detail_error=_optional_string(value.get("detail_error")),
+		)
+
+
+@dataclass(frozen=True, kw_only=True)
+class Level2Exclusion:
+	"""A search row that could not become a stable Level 2 listing."""
+
+	index: int
+	reason: str
+	listing_id: str | None = None
+	vin: str | None = None
+	received_type: str | None = None
+
+	def to_dict(self) -> dict[str, Any]:
+		return {
+			"index": self.index,
+			"reason": self.reason,
+			"listing_id": self.listing_id,
+			"vin": self.vin,
+			"received_type": self.received_type,
+		}
+
+	@classmethod
+	def from_dict(cls, value: Mapping[str, Any]) -> "Level2Exclusion":
+		return cls(
+			index=int(value["index"]),
+			reason=str(value["reason"]),
+			listing_id=_optional_string(value.get("listing_id")),
+			vin=_optional_string(value.get("vin")),
+			received_type=_optional_string(value.get("received_type")),
+		)
+
+
+@dataclass(frozen=True, kw_only=True)
+class Level2Collection:
+	"""Complete Level 2 acquisition result with raw source provenance."""
+
+	listings: tuple[Level2ListingRecord, ...]
+	exclusions: tuple[Level2Exclusion, ...]
+	request_params: dict[str, Any]
+	retrieved_at: str
+	raw_search_response: dict[str, Any]
+
+	def to_dict(self) -> dict[str, Any]:
+		return {
+			"listings": [item.to_dict() for item in self.listings],
+			"exclusions": [item.to_dict() for item in self.exclusions],
+			"request_params": self.request_params,
+			"retrieved_at": self.retrieved_at,
+			"raw_search_response": self.raw_search_response,
+		}
+
+	@classmethod
+	def from_dict(cls, value: Mapping[str, Any]) -> "Level2Collection":
+		listings = value.get("listings")
+		exclusions = value.get("exclusions")
+		if not isinstance(listings, list) or not isinstance(exclusions, list):
+			raise ValueError("cached Level 2 collection arrays are invalid")
+		return cls(
+			listings=tuple(Level2ListingRecord.from_dict(_mapping(item)) for item in listings),
+			exclusions=tuple(Level2Exclusion.from_dict(_mapping(item)) for item in exclusions),
+			request_params=_dictionary(value.get("request_params"), "request_params"),
+			retrieved_at=str(value["retrieved_at"]),
+			raw_search_response=_dictionary(
+				value.get("raw_search_response"), "raw_search_response"
+			),
+		)
+
+
+def collect_level2_listings(
+	client: Level2Client,
+	query: VisorListingQuery,
+	*,
+	max_listings: int = 100,
+	clock: Callable[[], datetime] | None = None,
+) -> Level2Collection:
+	"""Fetch an enriched search and standard detail sequentially for Level 2."""
+	if query.unsupported:
+		raise ValueError(f"unsupported query options: {sorted(query.unsupported)}")
+	if max_listings < 0:
+		raise ValueError("max_listings must not be negative")
+	now = clock or (lambda: datetime.now(timezone.utc))
+	request_params = level2_search_params(query)
+	response = client.filter_all_listings(
+		request_params,
+		max_listings=max_listings,
+	)
+	rows = response.get("data")
+	if not isinstance(rows, list):
+		raise ValueError("Level 2 listing search data must be an array")
+
+	listings: list[Level2ListingRecord] = []
+	exclusions: list[Level2Exclusion] = []
+	seen_ids: set[str] = set()
+	for index, raw_row in enumerate(rows):
+		if not isinstance(raw_row, Mapping):
+			exclusions.append(Level2Exclusion(
+				index=index,
+				reason="search_record_not_object",
+				received_type=type(raw_row).__name__,
+			))
+			continue
+		row = dict(raw_row)
+		listing_id = _optional_string(row.get("id"))
+		vin = _optional_string(row.get("vin"))
+		if listing_id is None:
+			exclusions.append(Level2Exclusion(
+				index=index,
+				reason="missing_stable_listing_id",
+				vin=vin,
+			))
+			continue
+		if listing_id in seen_ids:
+			exclusions.append(Level2Exclusion(
+				index=index,
+				reason="duplicate_stable_listing_id",
+				listing_id=listing_id,
+				vin=vin,
+			))
+			continue
+		seen_ids.add(listing_id)
+
+		detail, detail_error = _collect_detail(client, listing_id)
+		adapted = adapt_listing(row, detail)
+		if detail_error is not None:
+			adapted.setdefault("warnings", []).append({
+				"field": "detail",
+				"code": "source_error",
+				"message": "Listing detail could not be retrieved.",
+				"api_path": f"/v1/listings/{listing_id}",
+			})
+			adapted.setdefault("provenance", {})["detail"] = {
+				"kind": "unavailable",
+				"reason": "source_error",
+			}
+		listings.append(Level2ListingRecord(
+			listing_id=listing_id,
+			vin=vin,
+			listing=adapted,
+			search_record=row,
+			detail_record=detail,
+			detail_error=detail_error,
+		))
+
+	return Level2Collection(
+		listings=tuple(listings),
+		exclusions=tuple(exclusions),
+		request_params=_json_values(request_params),
+		retrieved_at=_aware_isoformat(now()),
+		raw_search_response=dict(response),
+	)
+
+
+def level2_search_params(query: VisorListingQuery) -> dict[str, Any]:
+	"""Return the enriched search parameters selected for Level 2."""
+	return {
+		**query.api_params(include_projection=False),
+		"fields": LEVEL2_SEARCH_FIELDS,
+		"include": LEVEL2_SEARCH_EXPANSIONS,
+	}
+
+
+def _collect_detail(
+	client: Level2Client,
+	listing_id: str,
+) -> tuple[dict[str, Any] | None, str | None]:
+	try:
+		response = client.get_listing(listing_id)
+	except (VisorAPIError, VisorTimeoutError) as error:
+		return None, str(error)
+	except Exception as error:
+		return None, type(error).__name__
+	data = response.get("data")
+	if not isinstance(data, Mapping):
+		return None, "invalid_detail_response"
+	return dict(data), None
+
+
+def _json_values(value: Mapping[str, Any]) -> dict[str, Any]:
+	return {
+		name: list(item) if isinstance(item, tuple) else item
+		for name, item in value.items()
+	}
+
+
+def _aware_isoformat(value: datetime) -> str:
+	if value.tzinfo is None or value.utcoffset() is None:
+		raise ValueError("Level 2 retrieval clock must return an aware datetime")
+	return value.isoformat()
+
+
+def _optional_string(value: Any) -> str | None:
+	if value is None:
+		return None
+	result = str(value).strip()
+	return result or None
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+	if not isinstance(value, Mapping):
+		raise ValueError("cached Level 2 item must be an object")
+	return value
+
+
+def _dictionary(value: Any, name: str) -> dict[str, Any]:
+	if not isinstance(value, Mapping):
+		raise ValueError(f"cached Level 2 {name} must be an object")
+	return dict(value)

--- a/visor_scraper/scraper.py
+++ b/visor_scraper/scraper.py
@@ -18,6 +18,9 @@ from utils.common import current_timestamp
 from utils.constants import *
 from utils.download import download_files
 from visor_scraper.helpers import *
+from visor_scraper.config import get_visor_api_key
+from visor_api import VisorClient, cached_level2_collection
+from visor_api.level2_service import Level2Collection
 from visor_api.query import VisorListingQuery
 
 logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
@@ -719,7 +722,84 @@ async def run_analysis(
             print("Level 3")
 
 
+def apply_level2_collection_metadata(
+    metadata: dict, collection: Level2Collection, cache_used: bool
+) -> None:
+    """Add Level 2 API acquisition provenance to legacy scraper metadata."""
+    pagination = collection.raw_search_response.get("pagination", {})
+    metadata["site_info"]["total_for_sale"] = pagination.get("total")
+    metadata["pagination"] = pagination
+    metadata["runtime"]["source"] = "visor_api"
+    metadata["sources"] = {
+        "visor_api": {
+            "listings": {
+                "endpoint": "/v1/listings",
+                "query": collection.request_params,
+                "retrieved_at": collection.retrieved_at,
+                "cache_used": cache_used,
+            },
+            "details": {
+                "endpoint": "/v1/listings/{listing_id}",
+                "requested": len(collection.listings),
+                "retrieved": sum(
+                    item.detail_record is not None for item in collection.listings
+                ),
+            },
+        }
+    }
+    for record in collection.listings:
+        for warning in record.listing.get("warnings", []):
+            metadata["warnings"].append(
+                {
+                    **warning,
+                    "listing_id": record.listing_id,
+                    "vin": record.vin,
+                }
+            )
+    for exclusion in collection.exclusions:
+        metadata["warnings"].append(
+            {
+                "field": "listings",
+                "code": "excluded_api_record",
+                "message": exclusion.reason,
+                "listing_id": exclusion.listing_id,
+                "vin": exclusion.vin,
+                "source_index": exclusion.index,
+                "received_type": exclusion.received_type,
+            }
+        )
+
+
+async def collect_and_run_level2_api(args: Namespace) -> None:
+    """Collect Level 2 API listings and pass them to the legacy analysis workflow."""
+    query = VisorListingQuery.from_url(args.url)
+    client = VisorClient(get_visor_api_key())
+    result = await asyncio.to_thread(
+        cached_level2_collection,
+        client,
+        query,
+        cache_dir=Path("cache") / "level2",
+        max_listings=args.max_listings,
+        force=args.force,
+    )
+    listings = [record.listing for record in result.collection.listings]
+    metadata = build_metadata(args)
+    apply_level2_collection_metadata(metadata, result.collection, result.cache_used)
+
+    timestamp = save_results(listings, metadata, args)
+    filename = (
+        f"output/raw/{args.make}_{args.model}_listings_{timestamp}.json".replace(
+            " ", "_"
+        )
+    )
+    await start_level2_analysis(metadata, listings, filename)
+
+
 async def scrape(args: Namespace) -> None:
+    if args.level2:
+        await collect_and_run_level2_api(args)
+        return
+
     # Try cache before touching the browser
     filename = try_get_cached_filename(args)
     if not args.force and filename and Path(filename).exists():


### PR DESCRIPTION
This is a complete updated of level 2. I confirmed that level 2 was properly connecting to the new API data but it was a good opportunity to address gaps in information that occurred between the last time it had been worked on. This is a fairly large change with lots of edits across a few files, some of which are nearly fully re-written.