### PR TITLE
feat(analysis): handle new vehicle risk

### DIFF
--- a/analysis/level2.py
+++ b/analysis/level2.py
@@ -12,6 +12,7 @@ from analysis.scoring import (
     determine_best_price,
     favorable_evidence_bonus,
     score_mileage_use,
+    score_new_vehicle_warranty,
     score_title_status,
     score_warranty_status,
 )
@@ -209,6 +210,35 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
 
         deal = assessment[0]
         pricing_visual = assessment[4]
+        is_new = str(listing.get("condition") or "").casefold() == "new"
+        if (report is None or not report.exists()) and is_new:
+            risk = 0
+            lc.risk_score = risk
+            price_score = deal_score_from_position(float(pricing_visual["marker_pct"]))
+            narrative.append("New vehicles do not require a vehicle history report.")
+            warranty_evidence = score_new_vehicle_warranty(listing, narrative)
+            favorable_evidence = max(-warranty_evidence, 0.0)
+            score_result = calculate_deal_score_result(
+                price_score, risk, favorable_evidence
+            )
+            pricing_visual["deal_score"] = score_result.final_score
+            pricing_visual["risk_summary"] = "none identified"
+            pricing_visual["risk_penalty"] = score_result.risk_penalty
+            pricing_visual["risk_score_subtracted"] = score_result.score_subtracted
+            if score_result.floor_applied:
+                pricing_visual["score_floor"] = score_result.low_risk_floor
+            pricing_visual["detail_scores"] = {
+                narrative[0]: f"+{round(price_score)} score",
+                narrative[-1]: (
+                    f"+{round(favorable_evidence_bonus(favorable_evidence, risk))} score"
+                ),
+            }
+            deal = score_result.rating
+            lc.deal_rating = deal
+            lc.narrative = narrative
+            ratings.append((listing, deal, risk, narrative, pricing_visual))
+            continue
+
         if report is None or not report.exists():
             narrative.append(
                 "A vehicle-history report was not collected, so risk and the final Level 2 rating are unavailable."
@@ -249,12 +279,7 @@ async def start_level2_analysis(metadata: dict, listings: list[dict], filename: 
             elif "warranty" in line.casefold():
                 detail_scores[line] = f"+{round(warranty_bonus)} score"
         pricing_visual["detail_scores"] = detail_scores
-        price_deal = deal
         deal = score_result.rating
-        if deal != price_deal:
-            narrative.append(
-                f"The combined score changes the price-only rating from {price_deal} to {deal}."
-            )
         lc.deal_rating = deal
         lc.narrative = narrative
 

--- a/analysis/level3.py
+++ b/analysis/level3.py
@@ -42,7 +42,10 @@ async def start_level3_analysis(metadata: dict, listings: list[dict], filename: 
 
         full_listing = next(l for l in listings if l.get("id") == listing.get("id"))
         report = get_report_dir(full_listing)
-        if report is None or not report.exists() or listing.get("price") is None:
+        is_new = str(listing.get("condition") or "").casefold() == "new"
+        if listing.get("price") is None:
+            continue
+        if not is_new and (report is None or not report.exists()):
             continue
 
         narrative: list[str] = []
@@ -53,8 +56,6 @@ async def start_level3_analysis(metadata: dict, listings: list[dict], filename: 
         fmr_high = int(ctx.cache_entries[cache_key].get("fmr_high") or 0)
         fmv = int(ctx.cache_entries[cache_key].get("fmv") or 0)
         msrp = int(ctx.cache_entries[cache_key].get("msrp") or 0)
-        is_new = str(listing.get("condition", "")).casefold() == "new"
-
         if not any((fpp_natl, fpp_local, fmv, msrp if is_new else 0)):
             narrative.append(
                 "Unable to provide ratings for this vehicle: no pricing data is available for this vehicle."
@@ -79,8 +80,15 @@ async def start_level3_analysis(metadata: dict, listings: list[dict], filename: 
             f"Deal bins are set at ${increment * 2} ({percent * 200}%) in size, placing the Fair midpoint at ${midpoint}."
         )
         # Risk ratings and deal adjustment
-        carfax: CarfaxData = get_carfax_data(report)
-        risk = rate_risk_level2(carfax, listing, narrative)
+        if report is not None and report.exists():
+            assert report is not None
+            carfax: CarfaxData = get_carfax_data(report)
+            risk = rate_risk_level2(carfax, listing, narrative)
+        else:
+            risk = 0
+            narrative.append(
+                "New vehicles do not require a vehicle history report."
+            )
         deal = adjust_deal_for_risk(deal, risk, narrative)
         ratings.append((listing, deal, risk, narrative))
 

--- a/analysis/normalization.py
+++ b/analysis/normalization.py
@@ -446,6 +446,8 @@ def normalize_listing(listing: dict) -> dict:
         "condition": listing.get("condition"),
         "price": to_int(listing.get("price")),
         "mileage": to_int(listing.get("mileage")),
+        "days_on_market": to_int(listing.get("days_on_market")),
+        "listed_at": listing.get("listed_at"),
         "is_hybrid": is_hybrid,
         "is_plugin": is_plugin,
         "fuel_type": fuel_type,

--- a/analysis/scoring.py
+++ b/analysis/scoring.py
@@ -703,6 +703,29 @@ def score_warranty_status(
     return rating
 
 
+def score_new_vehicle_warranty(
+    listing: dict, narrative: Optional[list[str]] = None
+) -> float:
+    """Score and describe the remaining standard 3-year/36,000-mile warranty."""
+    days_on_market = max(to_int(listing.get("days_on_market")) or 0, 0)
+    mileage = max(to_int(listing.get("mileage")) or 0, 0)
+    warranty_days = max((3 * 365) - days_on_market, 0)
+    basic_months = round(warranty_days / (365 / 12))
+    basic_miles = max(36_000 - mileage, 0)
+
+    miles_per_month = 15_000 / 12
+    mileage_months = basic_miles / miles_per_month if basic_miles > 0 else 0.0
+    effective_months = min(float(basic_months), mileage_months)
+    rating = -min(effective_months / 6.0, 2.0) if effective_months > 0 else 0.0
+
+    if narrative is not None:
+        narrative.append(
+            f"Warranty active: ~{basic_months} months, ~{basic_miles:,} miles remaining."
+        )
+
+    return rating
+
+
 def score_mileage_use(
     carfax: CarfaxData, listing: dict, narrative: Optional[list[str]] = None
 ) -> float:

--- a/docs/visor-api-migration.md
+++ b/docs/visor-api-migration.md
@@ -225,13 +225,15 @@ adapted listings to the existing `output/raw` envelope, and passes those listing
 the legacy Level 2 analysis and report pipeline. Level 1 remains on its separate
 facet-native path.
 
-Level 2 retains every returned listing in the report. Listings with compatible KBB
-pricing and a saved vehicle-history report receive the complete risk-adjusted
-rating. Listings with KBB pricing but no report receive a clearly separated price
-assessment; risk and the final Level 2 rating remain unavailable. Listings without
-usable pricing or a KBB mapping appear in an information-only section with the
-specific reason. Unfavorable complete ratings are displayed rather than reduced to
-summary counts.
+Level 2 retains every returned listing in the report. Used, certified, and
+unknown-condition listings with compatible KBB pricing and a saved vehicle-history
+report receive the complete risk-adjusted rating. New listings use a saved
+vehicle-history report when one is available; otherwise they receive a risk score
+of 0 without requiring one. Other listings with KBB pricing but no report receive a
+clearly separated price assessment; risk and the final Level 2 rating remain
+unavailable. Listings without usable pricing or a KBB mapping appear in an
+information-only section with the specific reason.
+Unfavorable complete ratings are displayed rather than reduced to summary counts.
 
 An end-to-end live test on 2026-07-21 collected 10 used 2024 Subaru Foresters,
 retrieved all 10 detail records, discovered three dealer history-report links,

--- a/templates/level2.html
+++ b/templates/level2.html
@@ -133,7 +133,7 @@
 			<h2>How ratings work</h2>
 			<ul>
 				<li>Price is compared with local KBB Fair Purchase Price, then national FPP or Fair Market Value when needed.</li>
-				<li>A complete rating requires a vehicle-history report. Title, accident, odometer, mileage, service, and warranty evidence can improve or worsen the price-based rating.</li>
+				<li>A complete rating requires a vehicle-history report unless the vehicle is new. Title, accident, odometer, mileage, service, and warranty evidence can improve or worsen the price-based rating.</li>
 				<li>Risk has an accelerating effect: small risks have limited impact, while moderate and high risks reduce Deal Score increasingly sharply.</li>
 				<li>Listings without a history report receive a price-only rating. Listings without a price or compatible KBB data are summarized by reason rather than displayed individually.</li>
 				<li>CARFAX warranty status is an estimate and should be confirmed with the manufacturer or dealer.</li>

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -16,6 +16,7 @@ from websocket import WebSocket
 
 from utils.download import (
 	complete_carfax_challenge,
+	collect_report_jobs,
 	download_images,
 	download_supplementary_files,
 	is_chrome_browser_window,
@@ -231,6 +232,45 @@ def test_missing_carfax_url_remains_due_after_poll_window():
 	cache = {"TESTVIN": {"dealer_fees": [["Unknown", -1, None]]}}
 
 	assert needs_poll(listing, cache)
+
+
+def test_new_vehicle_does_not_poll_only_for_missing_carfax():
+	listing = {
+		"vin": "NEWVIN",
+		"condition": "New",
+		"additional_docs": {"carfax_url": None},
+	}
+	cache = {"NEWVIN": {"dealer_fees": [["Unknown", -1, None]]}}
+
+	assert not needs_poll(listing, cache)
+
+
+@pytest.mark.parametrize("condition", ["Used", "Certified", None])
+def test_non_new_vehicle_still_polls_for_missing_carfax(condition):
+	listing = {
+		"vin": "TESTVIN",
+		"condition": condition,
+		"additional_docs": {"carfax_url": None},
+	}
+	cache = {"TESTVIN": {"dealer_fees": [["Unknown", -1, None]]}}
+
+	assert needs_poll(listing, cache)
+
+
+def test_new_vehicle_with_history_url_creates_download_job(output_dir, monkeypatch):
+	monkeypatch.setattr("utils.download.DOC_PATH", output_dir)
+	listing = {
+		"title": "2026 Test Vehicle",
+		"vin": "NEWVIN",
+		"condition": "new",
+		"additional_docs": {"carfax_url": "https://carfax.test/report"},
+	}
+
+	jobs = collect_report_jobs([listing])
+
+	assert len(jobs) == 1
+	assert jobs[0][0] == "carfax"
+	assert jobs[0][1] == "https://carfax.test/report"
 
 
 def test_carfax_challenge_wait_allows_user_to_complete_puzzle(monkeypatch):

--- a/tests/unit/test_level2_eligibility.py
+++ b/tests/unit/test_level2_eligibility.py
@@ -2,6 +2,7 @@ import shutil
 import uuid
 
 from pathlib import Path
+from unittest.mock import Mock
 
 from analysis import level2, reporting
 from analysis.reporting import (
@@ -111,6 +112,105 @@ async def test_level2_keeps_price_only_and_unmapped_listings(monkeypatch):
 	assert render_args[5] == [
 		(unmapped_listing, "The listing trim could not be mapped to compatible KBB pricing.")
 	]
+
+
+async def test_level2_rates_new_vehicle_without_history_report(monkeypatch):
+	listing = {
+		"id": "new-no-report",
+		"vin": "NEWVIN",
+		"title": "2026 Test Vehicle",
+		"condition": "New",
+		"price": 25_000,
+	}
+	ctx = AnalysisContext(make="Test", model="Vehicle")
+	context = ListingContext(listing_id="new-no-report", listing=listing)
+	ctx.listings = [context]
+
+	async def fake_prepare(*_args, **_kwargs):
+		return ctx
+
+	render_args: tuple = ()
+
+	async def fake_render(*args):
+		nonlocal render_args
+		render_args = args
+
+	monkeypatch.setattr(level2, "prepare_level2_analysis", fake_prepare)
+	monkeypatch.setattr(
+		level2,
+		"_price_assessment",
+		lambda _lc, narrative: narrative.append("Price evidence available.")
+		or ("Good", 0, 0, 0.0, {"marker_pct": 25.0}),
+	)
+	monkeypatch.setattr(level2, "render_level2_pdf", fake_render)
+
+	await level2.start_level2_analysis({}, [listing], "unused.json")
+
+	assert len(render_args[3]) == 1
+	assessed, _, risk, narrative, pricing = render_args[3][0]
+	assert assessed == listing
+	assert risk == 0
+	assert context.risk_score == 0
+	assert pricing["risk_summary"] == "none identified"
+	assert "New vehicles do not require a vehicle history report" in narrative
+	assert "Warranty active: ~36 months, ~36,000 miles remaining." in narrative
+	assert "New vehicles do not require a vehicle history report" not in pricing["detail_scores"]
+	assert not any("combined score changes" in line.casefold() for line in narrative)
+	assert render_args[4] == []
+
+
+async def test_level2_uses_existing_history_report_for_new_vehicle(monkeypatch):
+	report = Path("cache") / f"test-new-carfax-{uuid.uuid4().hex}.html"
+	report.parent.mkdir(parents=True, exist_ok=True)
+	report.write_text("saved report", encoding="utf-8")
+	listing = {
+		"id": "new-with-report",
+		"vin": "NEWVIN",
+		"title": "2026 Test Vehicle",
+		"condition": "New",
+		"price": 25_000,
+	}
+	ctx = AnalysisContext(make="Test", model="Vehicle")
+	ctx.listings = [ListingContext(
+		listing_id="new-with-report",
+		listing=listing,
+		report_path=str(report),
+	)]
+
+	async def fake_prepare(*_args, **_kwargs):
+		return ctx
+
+	render_args: tuple = ()
+
+	async def fake_render(*args):
+		nonlocal render_args
+		render_args = args
+
+	parser = Mock(return_value=object())
+	monkeypatch.setattr(level2, "prepare_level2_analysis", fake_prepare)
+	monkeypatch.setattr(
+		level2,
+		"_price_assessment",
+		lambda _lc, narrative: narrative.append("Price evidence available.")
+		or ("Good", 0, 0, 0.0, {"marker_pct": 25.0}),
+	)
+	monkeypatch.setattr(level2, "get_carfax_data", parser)
+	monkeypatch.setattr(level2, "score_title_status", lambda _carfax: 3.0)
+	monkeypatch.setattr(level2, "score_mileage_use", lambda *_args: 0.0)
+	monkeypatch.setattr(level2, "score_warranty_status", lambda *_args: 0.0)
+	monkeypatch.setattr(level2, "_risk_summary", lambda *_args: "reported history")
+	monkeypatch.setattr(level2, "render_level2_pdf", fake_render)
+
+	await level2.start_level2_analysis({}, [listing], "unused.json")
+
+	parser.assert_called_once_with(report)
+	assert render_args[3][0][2] == 3
+	assert render_args[3][0][4]["risk_summary"] == "reported history"
+	assert not any(
+		"New vehicles do not require a vehicle history report" in line
+		for line in render_args[3][0][3]
+	)
+	report.unlink()
 
 
 async def test_level2_uses_available_national_fpp_without_fmv(monkeypatch):

--- a/tests/unit/test_level2_scoring.py
+++ b/tests/unit/test_level2_scoring.py
@@ -9,6 +9,7 @@ from analysis.scoring import (
 	risk_penalty,
 	get_structure_score,
 	format_deal_score_narrative,
+	score_new_vehicle_warranty,
 	score_warranty_status,
 )
 from utils.models import CarfaxData, StructuralStatus
@@ -147,6 +148,19 @@ def test_warranty_bonus_uses_limiting_mileage_at_typical_use():
 
 	assert result == pytest.approx(-0.0916, abs=0.001)
 	assert narrative == ["Warranty active: ~5 months, ~687 miles remaining."]
+
+
+def test_new_vehicle_warranty_subtracts_listing_time_and_mileage():
+	narrative = []
+
+	result = score_new_vehicle_warranty(
+		{"days_on_market": 45, "mileage": 500}, narrative
+	)
+
+	assert result == -2.0
+	assert narrative == [
+		"Warranty active: ~35 months, ~35,500 miles remaining."
+	]
 
 
 def test_missing_warranty_information_is_neutral():

--- a/tests/unit/test_level3.py
+++ b/tests/unit/test_level3.py
@@ -1,0 +1,75 @@
+import uuid
+
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
+from analysis import level3
+from utils.models import AnalysisContext, ListingContext
+
+
+async def test_level3_rates_new_vehicle_without_history_report(monkeypatch):
+	listing = {
+		"id": "new-no-report",
+		"condition": "New",
+		"price": 25_000,
+	}
+	context = ListingContext(listing_id="new-no-report", listing=listing)
+	ctx = AnalysisContext(make="Test", model="Vehicle")
+	ctx.listings = [context]
+	ctx.cache_entries = {
+		"": {"fpp_natl": 26_000, "fpp_local": 0, "fmr_high": 0, "fmv": 0, "msrp": 0}
+	}
+
+	monkeypatch.setattr(level3, "prepare_level3_analysis", AsyncMock(return_value=ctx))
+	monkeypatch.setattr(level3, "get_report_dir", lambda _listing: None)
+	monkeypatch.setattr(
+		level3,
+		"get_carfax_data",
+		lambda _report: (_ for _ in ()).throw(AssertionError("CARFAX should not be parsed")),
+	)
+	adjust = Mock(return_value="Good")
+	monkeypatch.setattr(level3, "adjust_deal_for_risk", adjust)
+
+	await level3.start_level3_analysis({}, [listing], "unused.json")
+
+	adjust.assert_called_once()
+	assert adjust.call_args.args[1] == 0
+	assert any(
+		"New vehicles do not require a vehicle history report" in line
+		for line in adjust.call_args.args[2]
+	)
+
+
+async def test_level3_uses_existing_history_report_for_new_vehicle(monkeypatch):
+	report = Path("cache") / f"test-new-carfax-{uuid.uuid4().hex}.html"
+	report.parent.mkdir(parents=True, exist_ok=True)
+	report.write_text("saved report", encoding="utf-8")
+	listing = {
+		"id": "new-with-report",
+		"condition": "New",
+		"price": 25_000,
+	}
+	context = ListingContext(listing_id="new-with-report", listing=listing)
+	ctx = AnalysisContext(make="Test", model="Vehicle")
+	ctx.listings = [context]
+	ctx.cache_entries = {
+		"": {"fpp_natl": 26_000, "fpp_local": 0, "fmr_high": 0, "fmv": 0, "msrp": 0}
+	}
+
+	monkeypatch.setattr(level3, "prepare_level3_analysis", AsyncMock(return_value=ctx))
+	monkeypatch.setattr(level3, "get_report_dir", lambda _listing: report)
+	parser = Mock(return_value=object())
+	monkeypatch.setattr(level3, "get_carfax_data", parser)
+	monkeypatch.setattr(level3, "rate_risk_level2", Mock(return_value=4))
+	adjust = Mock(return_value="Good")
+	monkeypatch.setattr(level3, "adjust_deal_for_risk", adjust)
+
+	await level3.start_level3_analysis({}, [listing], "unused.json")
+
+	parser.assert_called_once_with(report)
+	assert adjust.call_args.args[1] == 4
+	assert not any(
+		"New vehicles do not require a vehicle history report" in line
+		for line in adjust.call_args.args[2]
+	)
+	report.unlink()

--- a/tests/unit/test_normalization.py
+++ b/tests/unit/test_normalization.py
@@ -3,7 +3,15 @@ from analysis.normalization import (
 	filter_valid_listings,
 	get_variant_map,
 	model_variant_title,
+	normalize_listing,
 )
+
+
+def test_normalization_preserves_listing_age_for_warranty_calculation():
+	normalized = normalize_listing({"days_on_market": 45, "listed_at": "2026-06-16"})
+
+	assert normalized["days_on_market"] == 45
+	assert normalized["listed_at"] == "2026-06-16"
 
 
 def test_model_match_uses_exact_base_unless_specialized_tokens_are_present():

--- a/utils/common.py
+++ b/utils/common.py
@@ -25,6 +25,11 @@ def current_timestamp():
     return datetime.now().strftime("%Y%m%d_%H%M%S")
 
 
+def requires_vehicle_history_report(listing: dict) -> bool:
+    """Return whether risk scoring requires a saved vehicle-history report."""
+    return str(listing.get("condition") or "").casefold() != "new"
+
+
 def get_time_delta(time1: str, time2: str) -> timedelta:
     dt1 = datetime.strptime(time1, "%Y%m%d_%H%M%S")
     dt2 = datetime.strptime(time2, "%Y%m%d_%H%M%S")

--- a/utils/download.py
+++ b/utils/download.py
@@ -22,6 +22,7 @@ from utils.common import (
     current_timestamp,
     get_time_delta,
     normalize_url,
+    requires_vehicle_history_report,
     to_https,
     stopwatch,
 )
@@ -886,6 +887,7 @@ def needs_poll(l: dict, cache: dict) -> bool:
     current = docs.get("carfax_url")
 
     cached_entry = cache.get(vin, {})
+    report_required = requires_vehicle_history_report(l)
     # 1: No cached record → poll to establish baseline
     if not cached_entry:
         return True
@@ -899,11 +901,11 @@ def needs_poll(l: dict, cache: dict) -> bool:
 
     cached_url = cached_entry.get("carfax_url")
     # 3: If URL is missing/unavailable → poll
-    if not cached_url and (not current or current == "Unavailable"):
+    if report_required and not cached_url and (not current or current == "Unavailable"):
         return True
 
     # 4: If URL exists but changed → poll again
-    if cached_url and current != cached_url:
+    if report_required and cached_url and current != cached_url:
         return True
 
     cached_fee = cached_entry.get("dealer_fees") or cached_entry.get("dealer_fee")


### PR DESCRIPTION
Use an available vehicle-history report before applying the zero-risk fallback for new vehicles.

Show remaining standard warranty based on listing age and mileage, and simplify Level 2 score explanations.

Keep history reports mandatory for used, certified, and unknown-condition vehicles.