### PR TITLE
fix(level2): handle local-only KBB pricing

### DIFF
--- a/analysis/analysis_utils.py
+++ b/analysis/analysis_utils.py
@@ -77,7 +77,8 @@ def get_relevant_entries(
     stripped_safe_model = safe_model.replace("-", "")
 
     for key, entry in entries.items():
-        url: str = entry.get("natl_source", "").lower()
+        source = entry.get("natl_source") or entry.get("local_source")
+        url = str(source or "").lower()
         if not url:
             continue
 

--- a/analysis/level2.py
+++ b/analysis/level2.py
@@ -93,6 +93,7 @@ def _price_assessment(
         fpp_local,
         fpp_natl,
         fmv,
+        narrative,
         msrp=msrp,
         is_new=is_new,
     )

--- a/analysis/normalization.py
+++ b/analysis/normalization.py
@@ -354,13 +354,14 @@ def filter_valid_listings(
             if variant_model_key
             else model
         )
-        entries = get_relevant_entries(cache_entries, make, variant_model, year)
         explicit_cache_key = l.get("kbb_cache_key")
-        cache_key = (
-            explicit_cache_key
-            if explicit_cache_key in cache_entries
-            else _best_usable_kbb_trim_match(base_trim, entries)
-        )
+        if explicit_cache_key is not None:
+            cache_key = explicit_cache_key
+        else:
+            entries = get_relevant_entries(
+                cache_entries, make, variant_model, year
+            )
+            cache_key = _best_usable_kbb_trim_match(base_trim, entries)
 
         if (
             not cache_key

--- a/tests/unit/test_kbb.py
+++ b/tests/unit/test_kbb.py
@@ -269,6 +269,59 @@ async def test_vin_first_pricing_reuses_configuration_and_enriches_national(
 	)
 
 
+async def test_vin_first_keeps_local_pricing_without_national_rows(monkeypatch):
+	listing = {
+		"id": "f150-xlt",
+		"vin": "1FTFW3L58SKE44302",
+		"year": 2025,
+		"condition": "New",
+		"trim": "XLT",
+		"body_style": "pickup",
+	}
+	local_source = (
+		"https://kbb.com/ford/f150-supercrew-cab/2025/"
+		"xlt-pickup-4d-5-1-2-ft/"
+	)
+	monkeypatch.setattr("analysis.kbb.create_kbb_browser", AsyncMock(
+		return_value=_fake_kbb_browser()
+	))
+	monkeypatch.setattr(
+		"analysis.kbb.get_used_style_url_from_vins",
+		AsyncMock(return_value=("XLT Pickup 4D 5 1/2 ft", local_source)),
+	)
+	monkeypatch.setattr(
+		"analysis.kbb._get_local_pricing_with_progress",
+		AsyncMock(return_value=(40_880, 48_980, 44_880, 41_300, local_source)),
+	)
+	monkeypatch.setattr(
+		"analysis.kbb.get_or_fetch_national_pricing",
+		AsyncMock(return_value=([], None)),
+	)
+	monkeypatch.setattr("analysis.kbb.save_cache", lambda _cache: None)
+	cache = {}
+
+	valuations = await get_vin_first_pricing_data(
+		"Ford",
+		"F-150",
+		[listing],
+		{"2025 Ford F150 SuperCrew Cab": [listing]},
+		cache,
+	)
+
+	cache_key = listing["kbb_cache_key"]
+	entry = cache["level23_entries"][cache_key]
+	assert cache_key == (
+		"2025 Ford F150 SuperCrew Cab XLT Pickup 4D 5 1/2 ft"
+	)
+	assert entry["pricing_basis"] == "vin"
+	assert entry["fpp_natl"] is None
+	assert entry["fpp_local"] == 44_880
+	assert entry["fmr_low"] == 40_880
+	assert entry["fmr_high"] == 48_980
+	assert "skip_reason" not in entry
+	assert valuations[0].kbb_trim == cache_key
+
+
 async def test_vin_first_does_not_fetch_local_price_without_vin_resolution(
 	monkeypatch,
 ):

--- a/tests/unit/test_level2_eligibility.py
+++ b/tests/unit/test_level2_eligibility.py
@@ -53,7 +53,7 @@ def test_level2_uses_msrp_only_for_new_vehicle_fallback():
 	narrative = []
 	assert level2._price_assessment(new, narrative) is not None
 	assert any("fallback benchmark" in message for message in narrative)
-	assert not any("MSRP" in message for message in narrative)
+	assert any("MSRP was used as the comparison value" in message for message in narrative)
 
 
 async def test_level2_keeps_price_only_and_unmapped_listings(monkeypatch):
@@ -293,8 +293,11 @@ async def test_level2_uses_available_national_fpp_without_fmv(monkeypatch):
 	assessed_listing, _, risk, narrative, pricing = render_args[4][0]
 	assert assessed_listing == listing
 	assert risk is None
-	assert not any("National FPP" in message for message in narrative)
-	assert narrative[0].startswith("Listing price is")
+	assert any(
+		"National FPP was used as the comparison value" in message
+		for message in narrative
+	)
+	assert narrative[1].startswith("Listing price is")
 	assert pricing["listing_price"] == listing["price"]
 	assert render_args[5] == []
 
@@ -595,8 +598,41 @@ def test_price_assessment_provides_visual_range_without_redundant_bullets():
 	assert 0 <= visual["marker_pct"] <= 100
 	assert not any("being listed at" in line for line in narrative)
 	assert not any("Deal bins are set" in line for line in narrative)
+	assert narrative[0].startswith("Local FPP was used as the comparison value")
 	assert "Listing price is 7.4% below the fair-price midpoint." in narrative
-	assert not any("comparison value" in line for line in narrative)
+
+
+def test_price_assessment_accepts_local_pricing_without_national_fpp():
+	lc = ListingContext(
+		listing_id="f150-xlt",
+		listing={"price": 45_000, "condition": "New"},
+		pricing=PricingAnchors(
+			fpp_natl=None,
+			fpp_local=44_880,
+			fmr_low=40_880,
+			fmr_high=48_980,
+			source_local=(
+				"https://kbb.com/ford/f150-supercrew-cab/2025/"
+				"xlt-pickup-4d-5-1-2-ft/"
+			),
+		),
+	)
+	narrative = []
+
+	assessment = level2._price_assessment(lc, narrative)
+
+	assert assessment is not None
+	visual = assessment[4]
+	assert (
+		visual["scale_low"]
+		< visual["great_high"]
+		< visual["good_high"]
+		< visual["fair_high"]
+		< visual["poor_high"]
+		< visual["scale_high"]
+	)
+	assert visual.get("kbb_url") == lc.pricing.source_local
+	assert narrative[0].startswith("Local FPP was used as the comparison value")
 
 
 def test_price_assessment_explains_percent_from_fair_midpoint():

--- a/tests/unit/test_normalization.py
+++ b/tests/unit/test_normalization.py
@@ -1,3 +1,4 @@
+from analysis.analysis_utils import get_relevant_entries
 from analysis.normalization import (
 	best_kbb_model_match,
 	filter_valid_listings,
@@ -5,6 +6,23 @@ from analysis.normalization import (
 	model_variant_title,
 	normalize_listing,
 )
+
+
+def test_relevant_entries_use_local_source_when_national_source_is_none():
+	cache_key = "2025 Ford F150 SuperCrew Cab XLT Pickup 4D 5 1/2 ft"
+	entry = {
+		"natl_source": None,
+		"local_source": (
+			"https://kbb.com/ford/f150-supercrew-cab/2025/"
+			"xlt-pickup-4d-5-1-2-ft/"
+		),
+	}
+
+	result = get_relevant_entries(
+		{cache_key: entry}, "Ford", "F150 SuperCrew Cab", "2025"
+	)
+
+	assert result == {cache_key: entry}
 
 
 def test_normalization_preserves_listing_age_for_warranty_calculation():
@@ -185,3 +203,59 @@ def test_filter_does_not_collapse_specialty_trim_to_partial_identity():
 
 	assert valid == []
 	assert skipped == [listing]
+
+
+def test_filter_does_not_fuzzy_match_when_explicit_cache_key_is_missing():
+	explicit_key = "2025 Ford F150 SuperCrew Cab XLT Pickup 4D 6 1/2 ft"
+	listing = {
+		"id": "f150-xlt",
+		"year": 2025,
+		"trim": "XLT",
+		"price": 45_000,
+		"kbb_cache_key": explicit_key,
+	}
+	entries = {
+		"2025 Ford F150 SuperCrew Cab XLT Pickup 4D 5 1/2 ft": {
+			"fpp_local": 44_880,
+			"pricing_basis": "vin",
+		},
+	}
+	variant_map = {"2025 Ford F150 SuperCrew Cab": [listing]}
+
+	valid, skipped, _ = filter_valid_listings(
+		"Ford", "F-150", [listing], entries, variant_map
+	)
+
+	assert valid == []
+	assert skipped == [listing]
+
+
+def test_filter_accepts_explicit_local_only_cache_entry():
+	cache_key = "2025 Ford F150 SuperCrew Cab XLT Pickup 4D 5 1/2 ft"
+	listing = {
+		"id": "f150-xlt",
+		"year": 2025,
+		"trim": "XLT",
+		"price": 45_000,
+		"kbb_cache_key": cache_key,
+	}
+	entries = {
+		cache_key: {
+			"natl_source": None,
+			"fpp_natl": None,
+			"local_source": (
+				"https://kbb.com/ford/f150-supercrew-cab/2025/"
+				"xlt-pickup-4d-5-1-2-ft/"
+			),
+			"fpp_local": 44_880,
+			"pricing_basis": "vin",
+		},
+	}
+	variant_map = {"2025 Ford F150 SuperCrew Cab": [listing]}
+
+	valid, skipped, _ = filter_valid_listings(
+		"Ford", "F-150", [listing], entries, variant_map
+	)
+
+	assert skipped == []
+	assert valid[0]["cache_key"] == cache_key


### PR DESCRIPTION
Use local sources when national pricing is unavailable and preserve explicit listing-to-cache associations during filtering.