### PR TITLE
265 add data model for listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ models, while pricing, ratings, risk, and narrative stay in analysis context and
 result models. Legacy saved dictionaries are converted at load boundaries and
 remain serializable in their established format during migration.
 
+The domain-model package also defines typed compatibility boundaries for KBB
+pricing caches, VIN resolutions, vehicle configurations, completed lookups and
+national tables; supplementary-resource attempt state; dealer fees, installed
+options, price history, warranty coverage, provenance and data warnings; and
+persisted listing datasets with metadata. These models preserve unknown legacy
+fields so individual subsystems can migrate without invalidating saved files.
+
 Raw API facts remain separate from calculated values and AI-written explanations.
 Important report inputs retain source provenance. Missing API fields remain
 unavailable rather than being guessed.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ The main boundaries are:
 - `tests/visor_authenticated/`: manual, explicitly opted-in API probes that may
   incur usage charges.
 
+Listing records cross those boundaries as the source-independent
+`deal_lens.models.Listing` domain model. Visor response classes remain transport
+models, while pricing, ratings, risk, and narrative stay in analysis context and
+result models. Legacy saved dictionaries are converted at load boundaries and
+remain serializable in their established format during migration.
+
 Raw API facts remain separate from calculated values and AI-written explanations.
 Important report inputs retain source provenance. Missing API fields remain
 unavailable rather than being guessed.

--- a/analysis/kbb.py
+++ b/analysis/kbb.py
@@ -1282,12 +1282,92 @@ def _listing_national_trim(listing: dict, national_trims: list[str]) -> str | No
 
 
 def _fresh_vin_first_national_rows(table: dict | None) -> list[tuple] | None:
-    if not table or not table.get("timestamp") or not table.get("rows"):
+    if (
+        not table
+        or not table.get("timestamp")
+        or not isinstance(table.get("rows"), list)
+    ):
         return None
     timestamp = datetime.fromisoformat(str(table["timestamp"]))
     if datetime.now() - timestamp >= KBB_CACHE_TTL:
         return None
     return [tuple(row) for row in table["rows"]]
+
+
+def _apply_complete_vin_first_cache(
+    make: str,
+    variant_map: dict[str, list[dict]],
+    entries: dict[str, dict],
+    configurations: dict[str, dict],
+    vin_resolutions: dict[str, dict],
+    national_tables: dict[str, dict],
+) -> bool:
+    """Assign cached pricing keys when every browser dependency is fresh."""
+    for ymm, variant_listings in variant_map.items():
+        if _fresh_vin_first_national_rows(national_tables.get(ymm)) is None:
+            return False
+        year = ymm[:4]
+        model_name = ymm.replace(year, "").replace(make, "").strip()
+        model_configurations = {
+            fingerprint: configuration
+            for fingerprint, configuration in configurations.items()
+            if (
+                str(configuration.get("year")) == year
+                and str(configuration.get("make", "")).casefold()
+                == make.casefold()
+                and str(configuration.get("model", "")).casefold()
+                == model_name.casefold()
+            )
+        }
+        for listing in variant_listings:
+            condition = str(listing.get("condition") or "").casefold()
+            if condition not in {"new", "used", "certified", "cpo"}:
+                continue
+            vin = str(listing.get("vin") or "").strip()
+            if not vin:
+                return False
+            fingerprint = str(
+                (vin_resolutions.get(vin) or {}).get("configuration") or ""
+            )
+            configuration = model_configurations.get(fingerprint)
+            if not configuration:
+                compatible = [
+                    candidate
+                    for candidate in model_configurations.values()
+                    if _configuration_matches_listing(candidate, listing)
+                ]
+                if len(compatible) != 1:
+                    return False
+                configuration = compatible[0]
+            style = str(configuration.get("style") or "")
+            body_style = (
+                _listing_configuration_value(listing, "body_style")
+                or str(configuration.get("body_style") or "")
+            )
+            if _complete_kbb_style_with_body(style, body_style) != style:
+                return False
+            cache_key = str(configuration.get("cache_key") or "")
+            entry = entries.get(cache_key)
+            if not cache_key or entry is None or not is_local_fresh(entry):
+                return False
+            listing["kbb_cache_key"] = cache_key
+    return True
+
+
+def _vin_first_valuations(
+    make: str,
+    variant_map: dict[str, list[dict]],
+    entries: dict[str, dict],
+) -> list[TrimValuation]:
+    relevant_models = {
+        key.replace(key[:4], "").replace(make, "").strip().casefold()
+        for key in variant_map
+    }
+    return [
+        TrimValuation.from_dict(entry)
+        for entry in entries.values()
+        if str(entry.get("model", "")).casefold() in relevant_models
+    ]
 
 
 async def _prefetch_vin_first_national_tables(
@@ -1551,6 +1631,17 @@ async def get_vin_first_pricing_data(
     national_tables: dict[str, dict] = cache.setdefault("level23_national_tables", {})
     relevant_slugs = get_model_slug_map(make, variant_map)
 
+    if _apply_complete_vin_first_cache(
+        make,
+        variant_map,
+        entries,
+        configurations,
+        vin_resolutions,
+        national_tables,
+    ):
+        logger.info("Using complete cached KBB pricing without starting browser")
+        return _vin_first_valuations(make, variant_map, entries)
+
     progress = cli_progress()
     with progress.status("Starting KBB browser"):
         request, browser, context, page = await create_kbb_browser()
@@ -1749,15 +1840,7 @@ async def get_vin_first_pricing_data(
             pass
         save_cache(cache)
 
-    valuations = []
-    for entry in entries.values():
-        if str(entry.get("model", "")).casefold() not in {
-            key.replace(key[:4], "").replace(make, "").strip().casefold()
-            for key in variant_map
-        }:
-            continue
-        valuations.append(TrimValuation.from_dict(entry))
-    return valuations
+    return _vin_first_valuations(make, variant_map, entries)
 
 
 async def get_pricing_data(

--- a/analysis/kbb.py
+++ b/analysis/kbb.py
@@ -1337,6 +1337,10 @@ def _apply_complete_vin_first_cache(
                     if _configuration_matches_listing(candidate, listing)
                 ]
                 if len(compatible) != 1:
+                    if _vin_resolution_unavailable_fresh(
+                        vin_resolutions.get(vin)
+                    ):
+                        continue
                     return False
                 configuration = compatible[0]
             style = str(configuration.get("style") or "")
@@ -1352,6 +1356,19 @@ def _apply_complete_vin_first_cache(
                 return False
             listing["kbb_cache_key"] = cache_key
     return True
+
+
+def _vin_resolution_unavailable_fresh(value: dict | None) -> bool:
+    if not value or value.get("status") != "unavailable":
+        return False
+    timestamp = value.get("timestamp")
+    if not timestamp:
+        return False
+    try:
+        checked_at = datetime.fromisoformat(str(timestamp))
+    except ValueError:
+        return False
+    return datetime.now() - checked_at < KBB_CACHE_TTL
 
 
 def _vin_first_valuations(
@@ -1523,6 +1540,9 @@ async def _resolve_vin_first_variant(
                 )
 
         if not configuration:
+            if _vin_resolution_unavailable_fresh(vin_resolutions.get(vin)):
+                logger.debug("Using cached unavailable KBB VIN result for %s", vin)
+                continue
             resolution = await get_used_style_url_from_vins(
                 page,
                 year,
@@ -1535,6 +1555,11 @@ async def _resolve_vin_first_variant(
                 logger.warning(
                     "KBB VIN did not resolve a used style for VIN %s", vin
                 )
+                vin_resolutions[vin] = {
+                    "configuration": None,
+                    "status": "unavailable",
+                    "timestamp": datetime.now().isoformat(),
+                }
                 continue
             style, style_url = resolution
             fingerprint = _configuration_fingerprint(

--- a/analysis/normalization.py
+++ b/analysis/normalization.py
@@ -1,4 +1,6 @@
 from collections import defaultdict
+from collections.abc import Mapping
+from typing import Any
 from difflib import SequenceMatcher
 
 from analysis.kbb_collector import get_missing_models
@@ -388,7 +390,7 @@ def filter_valid_listings(
     return valid_entries, skipped_listings, skip_summary
 
 
-def normalize_listing(listing: dict) -> dict:
+def normalize_listing(listing: Mapping[str, Any]) -> dict[str, Any]:
     """Convert a raw listing into the minimal Level-1 schema."""
 
     addl = listing.get("additional_docs", {}) or {}

--- a/analysis/workflow.py
+++ b/analysis/workflow.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 from analysis.analysis_utils import (
     check_missing_docs,
     download_files,
@@ -15,6 +17,7 @@ from utils.cache import load_cache
 from utils.constants import *
 from utils.download import needs_supplementary_info
 from utils.models import AnalysisContext, ListingContext, PricingAnchors
+from deal_lens.models import Listing, listing_from_legacy
 
 
 def build_analysis_context(metadata: dict) -> AnalysisContext:
@@ -43,7 +46,9 @@ async def populate_pricing_data(
 
 
 def populate_filtered_listings(
-    ctx: AnalysisContext, listings: list[dict], full_listings: list[dict] | None = None
+    ctx: AnalysisContext,
+    listings: list[dict],
+    full_listings: Sequence[dict | Listing] | None = None,
 ):
     valid_data, skipped_listings, skip_summary = filter_valid_listings(
         ctx.make, ctx.model, listings, ctx.cache_entries, ctx.variant_map
@@ -52,7 +57,7 @@ def populate_filtered_listings(
     ctx.skipped_listings = skipped_listings
     ctx.skip_summary = skip_summary
 
-    full_listings = full_listings or listings
+    source_listings: Sequence[dict | Listing] = full_listings or listings
 
     ctx.listings = []
     for vd in valid_data:
@@ -63,9 +68,12 @@ def populate_filtered_listings(
         vin = str(listing.get("vin", "") or "")
 
         # Find the matching “full listing” once, here (so level2 doesn’t do it)
-        full = next((l for l in full_listings if str(l.get("id", "")) == lid), listing)
+        full = next((l for l in source_listings if str(l.get("id", "")) == lid), listing)
+        full_data = full.to_legacy_dict() if isinstance(full, Listing) else dict(full)
+        # Keep calculated normalization fields while retaining every source fact.
+        model = listing_from_legacy({**full_data, **listing})
 
-        report = get_report_dir(full)
+        report = get_report_dir(full_data)
         report_path = str(report) if report else None
 
         entry = ctx.cache_entries.get(cache_key, {})
@@ -88,8 +96,7 @@ def populate_filtered_listings(
                 cache_key=cache_key,
                 year=vd["year"],
                 base_trim=vd["base_trim"],
-                listing=listing,
-                full_listing=full,
+                listing=model,
                 report_path=report_path,
                 pricing=pricing,
             )

--- a/deal_lens/cli.py
+++ b/deal_lens/cli.py
@@ -15,6 +15,7 @@ from utils.constants import *
 from utils.download import download_files
 from deal_lens.cli_support import *
 from deal_lens.config import get_visor_api_key, get_visor_rate_limits
+from deal_lens.models import Listing
 from deal_lens.progress import CLI_CONSOLE, cli_progress
 from utils.progress import ProgressReporter
 from visor_api import (
@@ -224,7 +225,11 @@ async def collect_and_run_level2_api(args: Namespace) -> None:
         force=args.force,
         progress=progress,
     )
-    listings = [record.listing for record in result.collection.listings]
+    listings = [
+        record.listing.to_legacy_dict()
+        if isinstance(record.listing, Listing) else record.listing
+        for record in result.collection.listings
+    ]
     metadata = build_metadata(args)
     apply_level2_collection_metadata(metadata, result.collection, result.cache_used)
 

--- a/deal_lens/models/__init__.py
+++ b/deal_lens/models/__init__.py
@@ -1,0 +1,19 @@
+"""Stable DealLens domain models."""
+
+from deal_lens.models.listing import (
+	Listing,
+	ListingCondition,
+	ListingDocuments,
+	Seller,
+	Vehicle,
+	listing_from_legacy,
+)
+
+__all__ = [
+	"Listing",
+	"ListingCondition",
+	"ListingDocuments",
+	"Seller",
+	"Vehicle",
+	"listing_from_legacy",
+]

--- a/deal_lens/models/__init__.py
+++ b/deal_lens/models/__init__.py
@@ -1,5 +1,33 @@
 """Stable DealLens domain models."""
 
+from deal_lens.models.common import (
+	DataWarning,
+	DealerFee,
+	InstalledOption,
+	PriceHistoryRecord,
+	ResourceState,
+	SourceProvenance,
+	SupplementaryResourceStatus,
+	SupplementaryStatus,
+	WarrantyCoverage,
+)
+from deal_lens.models.dataset import (
+	DatasetRuntime,
+	DatasetVehicle,
+	ListingDataset,
+	ListingDatasetMetadata,
+)
+from deal_lens.models.kbb import (
+	KBBLookupState,
+	KBBLookupStatus,
+	KBBNationalRow,
+	KBBNationalTable,
+	KBBPricingBasis,
+	KBBPricingCache,
+	KBBPricingEntry,
+	KBBVehicleConfiguration,
+	KBBVinResolution,
+)
 from deal_lens.models.listing import (
 	Listing,
 	ListingCondition,
@@ -10,10 +38,32 @@ from deal_lens.models.listing import (
 )
 
 __all__ = [
+	"DataWarning",
+	"DatasetRuntime",
+	"DatasetVehicle",
+	"DealerFee",
+	"InstalledOption",
+	"KBBLookupState",
+	"KBBLookupStatus",
+	"KBBNationalRow",
+	"KBBNationalTable",
+	"KBBPricingBasis",
+	"KBBPricingCache",
+	"KBBPricingEntry",
+	"KBBVehicleConfiguration",
+	"KBBVinResolution",
 	"Listing",
 	"ListingCondition",
+	"ListingDataset",
+	"ListingDatasetMetadata",
 	"ListingDocuments",
+	"PriceHistoryRecord",
+	"ResourceState",
 	"Seller",
+	"SourceProvenance",
+	"SupplementaryResourceStatus",
+	"SupplementaryStatus",
 	"Vehicle",
+	"WarrantyCoverage",
 	"listing_from_legacy",
 ]

--- a/deal_lens/models/common.py
+++ b/deal_lens/models/common.py
@@ -1,0 +1,288 @@
+"""Typed child records shared by listing and enrichment models."""
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field as dataclass_field
+from datetime import datetime
+from enum import StrEnum
+from typing import Any, Self
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class DataWarning:
+	code: str
+	field: str
+	message: str
+	source: str | None = None
+	source_path: str | None = None
+	listing_id: str | None = None
+	vin: str | None = None
+	extra: dict[str, Any] = dataclass_field(default_factory=dict, repr=False)
+
+	@classmethod
+	def from_dict(cls, value: Mapping[str, Any]) -> Self:
+		known = {"code", "field", "message", "source", "api_path", "source_path", "listing_id", "vin"}
+		return cls(
+			code=str(value.get("code") or "unknown"),
+			field=str(value.get("field") or "unknown"),
+			message=str(value.get("message") or ""),
+			source=_optional_string(value.get("source")),
+			source_path=_optional_string(value.get("source_path") or value.get("api_path")),
+			listing_id=_optional_string(value.get("listing_id")),
+			vin=_optional_string(value.get("vin")),
+			extra={key: item for key, item in value.items() if key not in known},
+		)
+
+	def to_dict(self) -> dict[str, Any]:
+		result = dict(self.extra)
+		result.update({"code": self.code, "field": self.field, "message": self.message})
+		for key, item in (
+			("source", self.source), ("api_path", self.source_path),
+			("listing_id", self.listing_id), ("vin", self.vin),
+		):
+			if item is not None:
+				result[key] = item
+		return result
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class SourceProvenance:
+	kind: str
+	source_path: str | None = None
+	reason: str | None = None
+	rule: str | None = None
+	inputs: tuple[str, ...] = ()
+	extra: dict[str, Any] = dataclass_field(default_factory=dict, repr=False)
+
+	@classmethod
+	def from_dict(cls, value: Mapping[str, Any]) -> Self:
+		known = {"kind", "api_path", "source_path", "reason", "rule", "inputs"}
+		return cls(
+			kind=str(value.get("kind") or "unknown"),
+			source_path=_optional_string(value.get("source_path") or value.get("api_path")),
+			reason=_optional_string(value.get("reason")),
+			rule=_optional_string(value.get("rule")),
+			inputs=tuple(str(item) for item in value.get("inputs") or ()),
+			extra={key: item for key, item in value.items() if key not in known},
+		)
+
+	def to_dict(self) -> dict[str, Any]:
+		result = dict(self.extra)
+		result["kind"] = self.kind
+		for key, item in (
+			("api_path", self.source_path), ("reason", self.reason),
+			("rule", self.rule),
+		):
+			if item is not None:
+				result[key] = item
+		if self.inputs:
+			result["inputs"] = list(self.inputs)
+		return result
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class DealerFee:
+	name: str
+	amount: float | None
+	included: bool | None = None
+	description: str | None = None
+
+	@classmethod
+	def from_legacy(cls, value: Any) -> Self:
+		if isinstance(value, Mapping):
+			return cls(
+				name=str(value.get("name") or value.get("label") or "Unknown"),
+				amount=_optional_float(value.get("amount", value.get("cost"))),
+				included=_optional_bool(value.get("included")),
+				description=_optional_string(value.get("description")),
+			)
+		if isinstance(value, (list, tuple)):
+			items = [*value, None, None, None, None]
+			return cls(
+				name=str(items[0] or "Unknown"), amount=_optional_float(items[1]),
+				included=_optional_bool(items[2]), description=_optional_string(items[3]),
+			)
+		raise ValueError("dealer fee must be an object or sequence")
+
+	def to_legacy(self) -> tuple[str, float | None, bool | None, str | None]:
+		return self.name, self.amount, self.included, self.description
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class PriceHistoryRecord:
+	changed_at: str | None
+	price: float | None
+	price_change: float | None = None
+	mileage: int | None = None
+	price_before: float | None = None
+	price_after: float | None = None
+	extra: dict[str, Any] = dataclass_field(default_factory=dict, repr=False)
+
+	@classmethod
+	def from_dict(cls, value: Mapping[str, Any]) -> Self:
+		known = {"date", "changed_at", "price", "price_change", "mileage", "price_before", "price_after"}
+		return cls(
+			changed_at=_optional_string(value.get("changed_at") or value.get("date")),
+			price=_optional_float(value.get("price")),
+			price_change=_optional_float(value.get("price_change")),
+			mileage=_optional_int(value.get("mileage")),
+			price_before=_optional_float(value.get("price_before")),
+			price_after=_optional_float(value.get("price_after")),
+			extra={key: item for key, item in value.items() if key not in known},
+		)
+
+	def to_dict(self) -> dict[str, Any]:
+		result = dict(self.extra)
+		for key, item in (
+			("date", self.changed_at), ("price", self.price),
+			("price_change", self.price_change), ("mileage", self.mileage),
+			("price_before", self.price_before), ("price_after", self.price_after),
+		):
+			if item is not None:
+				result[key] = item
+		return result
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class InstalledOption:
+	name: str
+	price: float | None = None
+	code: str | None = None
+	extra: dict[str, Any] = dataclass_field(default_factory=dict, repr=False)
+
+	@classmethod
+	def from_dict(cls, value: Mapping[str, Any]) -> Self:
+		known = {"name", "price", "msrp", "code"}
+		return cls(
+			name=str(value.get("name") or "Unknown"),
+			price=_optional_float(value.get("price", value.get("msrp"))),
+			code=_optional_string(value.get("code")),
+			extra={key: item for key, item in value.items() if key not in known},
+		)
+
+	def to_dict(self) -> dict[str, Any]:
+		return {**self.extra, "name": self.name, "price": self.price, "code": self.code}
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class WarrantyCoverage:
+	name: str
+	status: str | None = None
+	months_remaining: int | None = None
+	miles_remaining: int | None = None
+	extra: dict[str, Any] = dataclass_field(default_factory=dict, repr=False)
+
+	@classmethod
+	def from_dict(cls, value: Mapping[str, Any]) -> Self:
+		known = {"name", "type", "status", "months_remaining", "miles_remaining"}
+		return cls(
+			name=str(value.get("name") or value.get("type") or "Unknown"),
+			status=_optional_string(value.get("status")),
+			months_remaining=_optional_int(value.get("months_remaining")),
+			miles_remaining=_optional_int(value.get("miles_remaining")),
+			extra={key: item for key, item in value.items() if key not in known},
+		)
+
+	def to_dict(self) -> dict[str, Any]:
+		return {
+			**self.extra, "name": self.name, "status": self.status,
+			"months_remaining": self.months_remaining,
+			"miles_remaining": self.miles_remaining,
+		}
+
+
+class ResourceState(StrEnum):
+	AVAILABLE = "available"
+	UNAVAILABLE = "unavailable"
+	FAILED = "failed"
+	DOWNLOADED = "downloaded"
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class SupplementaryResourceStatus:
+	state: ResourceState
+	source_url: str | None = None
+	attempted_at: datetime | None = None
+	retry_after: datetime | None = None
+	failure_reason: str | None = None
+	http_status: int | None = None
+
+	@classmethod
+	def from_dict(cls, value: Mapping[str, Any]) -> Self:
+		return cls(
+			state=ResourceState(str(value["status"])),
+			source_url=_optional_string(value.get("source_url")),
+			attempted_at=_optional_datetime(value.get("attempted_at")),
+			retry_after=_optional_datetime(value.get("retry_after")),
+			failure_reason=_optional_string(value.get("failure_reason")),
+			http_status=_optional_int(value.get("http_status")),
+		)
+
+	def to_dict(self) -> dict[str, Any]:
+		return {
+			"status": self.state.value,
+			"source_url": self.source_url,
+			"attempted_at": self.attempted_at.isoformat() if self.attempted_at else None,
+			"retry_after": self.retry_after.isoformat() if self.retry_after else None,
+			"failure_reason": self.failure_reason,
+			"http_status": self.http_status,
+		}
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class SupplementaryStatus:
+	image: SupplementaryResourceStatus | None = None
+	window_sticker: SupplementaryResourceStatus | None = None
+	dealer_data: SupplementaryResourceStatus | None = None
+	vehicle_history: SupplementaryResourceStatus | None = None
+
+	@classmethod
+	def from_dict(cls, value: Mapping[str, Any]) -> Self:
+		def resource(name: str) -> SupplementaryResourceStatus | None:
+			item = value.get(name)
+			return SupplementaryResourceStatus.from_dict(item) if isinstance(item, Mapping) else None
+		return cls(
+			image=resource("image"), window_sticker=resource("window_sticker"),
+			dealer_data=resource("dealer_data"), vehicle_history=resource("vehicle_history"),
+		)
+
+	def to_dict(self) -> dict[str, Any]:
+		return {
+			name: item.to_dict()
+			for name, item in (
+				("image", self.image), ("window_sticker", self.window_sticker),
+				("dealer_data", self.dealer_data),
+				("vehicle_history", self.vehicle_history),
+			)
+			if item is not None
+		}
+
+
+def _optional_string(value: Any) -> str | None:
+	return str(value) if value is not None else None
+
+
+def _optional_float(value: Any) -> float | None:
+	try:
+		return float(value) if value is not None else None
+	except (TypeError, ValueError):
+		return None
+
+
+def _optional_int(value: Any) -> int | None:
+	try:
+		return int(value) if value is not None else None
+	except (TypeError, ValueError):
+		return None
+
+
+def _optional_bool(value: Any) -> bool | None:
+	return value if isinstance(value, bool) else None
+
+
+def _optional_datetime(value: Any) -> datetime | None:
+	if value is None:
+		return None
+	try:
+		return datetime.fromisoformat(str(value))
+	except ValueError:
+		return None

--- a/deal_lens/models/dataset.py
+++ b/deal_lens/models/dataset.py
@@ -1,0 +1,117 @@
+"""Persisted listing dataset and metadata models."""
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Self
+
+from deal_lens.models.common import DataWarning
+from deal_lens.models.listing import Listing, listing_from_legacy
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class DatasetVehicle:
+	make: str
+	model: str
+	trim: str | None = None
+	year: str | int | None = None
+
+	@classmethod
+	def from_dict(cls, value: Mapping[str, Any]) -> Self:
+		return cls(
+			make=str(value.get("make") or ""), model=str(value.get("model") or ""),
+			trim=str(value["trim"]) if value.get("trim") is not None else None,
+			year=value.get("year"),
+		)
+
+	def to_dict(self) -> dict[str, Any]:
+		return {"make": self.make, "model": self.model, "trim": self.trim, "year": self.year}
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class DatasetRuntime:
+	timestamp: str
+	url: str | None = None
+	source: str | None = None
+	extra: dict[str, Any] = field(default_factory=dict, repr=False)
+
+	@classmethod
+	def from_dict(cls, value: Mapping[str, Any]) -> Self:
+		known = {"timestamp", "url", "source"}
+		return cls(
+			timestamp=str(value.get("timestamp") or ""),
+			url=str(value["url"]) if value.get("url") is not None else None,
+			source=str(value["source"]) if value.get("source") is not None else None,
+			extra={key: item for key, item in value.items() if key not in known},
+		)
+
+	def to_dict(self) -> dict[str, Any]:
+		return {**self.extra, "timestamp": self.timestamp, "url": self.url, "source": self.source}
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class ListingDatasetMetadata:
+	vehicle: DatasetVehicle
+	runtime: DatasetRuntime
+	filters: dict[str, Any] = field(default_factory=dict)
+	site_info: dict[str, Any] = field(default_factory=dict)
+	warnings: tuple[DataWarning, ...] = ()
+	sources: dict[str, Any] = field(default_factory=dict)
+	extra: dict[str, Any] = field(default_factory=dict, repr=False)
+
+	@classmethod
+	def from_dict(cls, value: Mapping[str, Any]) -> Self:
+		known = {"vehicle", "runtime", "filters", "site_info", "warnings", "sources"}
+		vehicle = value.get("vehicle")
+		runtime = value.get("runtime")
+		if not isinstance(vehicle, Mapping) or not isinstance(runtime, Mapping):
+			raise ValueError("dataset metadata requires vehicle and runtime objects")
+		warnings = value.get("warnings") or []
+		if not isinstance(warnings, list):
+			raise ValueError("dataset metadata warnings must be an array")
+		return cls(
+			vehicle=DatasetVehicle.from_dict(vehicle),
+			runtime=DatasetRuntime.from_dict(runtime),
+			filters=_dict(value.get("filters")), site_info=_dict(value.get("site_info")),
+			warnings=tuple(DataWarning.from_dict(item) for item in warnings if isinstance(item, Mapping)),
+			sources=_dict(value.get("sources")),
+			extra={key: item for key, item in value.items() if key not in known},
+		)
+
+	def to_dict(self) -> dict[str, Any]:
+		return {
+			**self.extra, "vehicle": self.vehicle.to_dict(), "filters": self.filters,
+			"site_info": self.site_info, "runtime": self.runtime.to_dict(),
+			"warnings": [warning.to_dict() for warning in self.warnings],
+			**({"sources": self.sources} if self.sources else {}),
+		}
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class ListingDataset:
+	metadata: ListingDatasetMetadata
+	listings: tuple[Listing, ...]
+	extra: dict[str, Any] = field(default_factory=dict, repr=False)
+
+	@classmethod
+	def from_dict(cls, value: Mapping[str, Any]) -> Self:
+		metadata = value.get("metadata")
+		listings = value.get("listings")
+		if not isinstance(metadata, Mapping):
+			raise ValueError("listing dataset metadata must be an object")
+		if not isinstance(listings, list):
+			raise ValueError("listing dataset listings must be an array")
+		return cls(
+			metadata=ListingDatasetMetadata.from_dict(metadata),
+			listings=tuple(listing_from_legacy(item) for item in listings if isinstance(item, Mapping)),
+			extra={key: item for key, item in value.items() if key not in {"metadata", "listings"}},
+		)
+
+	def to_dict(self) -> dict[str, Any]:
+		return {
+			**self.extra, "metadata": self.metadata.to_dict(),
+			"listings": [listing.to_legacy_dict() for listing in self.listings],
+		}
+
+
+def _dict(value: Any) -> dict[str, Any]:
+	return dict(value) if isinstance(value, Mapping) else {}

--- a/deal_lens/models/kbb.py
+++ b/deal_lens/models/kbb.py
@@ -1,0 +1,267 @@
+"""Canonical models for KBB pricing facts and persisted lookup state."""
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import StrEnum
+from typing import Any, Self
+
+
+Number = int | float
+
+
+class KBBPricingBasis(StrEnum):
+	NEW = "new"
+	USED = "used"
+	VIN = "vin"
+	NATIONAL = "national"
+
+
+class KBBLookupState(StrEnum):
+	COMPLETE = "complete"
+	FAILED = "failed"
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class KBBPricingEntry:
+	model: str | None = None
+	kbb_trim: str | None = None
+	msrp: Number | None = None
+	fpp_natl: Number | None = None
+	fmr_low: Number | None = None
+	fmr_high: Number | None = None
+	fpp_local: Number | None = None
+	fmv: Number | None = None
+	natl_source: str | None = None
+	local_source: str | None = None
+	natl_timestamp: datetime | None = None
+	local_timestamp: datetime | None = None
+	pricing_basis: KBBPricingBasis | None = None
+	uncertainty: str | None = None
+	skip_reason: str | None = None
+	extra: dict[str, Any] = field(default_factory=dict, repr=False)
+
+	@property
+	def has_pricing(self) -> bool:
+		return any(value is not None for value in (
+			self.msrp, self.fpp_natl, self.fpp_local, self.fmv,
+		))
+
+	@classmethod
+	def from_dict(cls, value: Mapping[str, Any]) -> Self:
+		known = {
+			"model", "kbb_trim", "msrp", "fpp_natl", "fmr_low", "fmr_high",
+			"fpp_local", "fmv", "natl_source", "local_source",
+			"natl_timestamp", "local_timestamp", "pricing_basis",
+			"uncertainty", "skip_reason",
+		}
+		basis = value.get("pricing_basis")
+		try:
+			pricing_basis = KBBPricingBasis(str(basis)) if basis else None
+		except ValueError:
+			pricing_basis = None
+		return cls(
+			model=_string(value.get("model")), kbb_trim=_string(value.get("kbb_trim")),
+			msrp=_number(value.get("msrp")), fpp_natl=_number(value.get("fpp_natl")),
+			fmr_low=_number(value.get("fmr_low")), fmr_high=_number(value.get("fmr_high")),
+			fpp_local=_number(value.get("fpp_local")), fmv=_number(value.get("fmv")),
+			natl_source=_string(value.get("natl_source")),
+			local_source=_string(value.get("local_source")),
+			natl_timestamp=_datetime(value.get("natl_timestamp")),
+			local_timestamp=_datetime(value.get("local_timestamp")),
+			pricing_basis=pricing_basis,
+			uncertainty=_string(value.get("uncertainty")),
+			skip_reason=_string(value.get("skip_reason")),
+			extra={key: item for key, item in value.items() if key not in known},
+		)
+
+	def to_dict(self) -> dict[str, Any]:
+		return {
+			**self.extra,
+			"model": self.model, "kbb_trim": self.kbb_trim, "msrp": self.msrp,
+			"fpp_natl": self.fpp_natl, "fmr_low": self.fmr_low,
+			"fmr_high": self.fmr_high, "fpp_local": self.fpp_local,
+			"fmv": self.fmv, "natl_source": self.natl_source,
+			"local_source": self.local_source,
+			"natl_timestamp": _isoformat(self.natl_timestamp),
+			"local_timestamp": _isoformat(self.local_timestamp),
+			"pricing_basis": self.pricing_basis.value if self.pricing_basis else None,
+			"uncertainty": self.uncertainty, "skip_reason": self.skip_reason,
+		}
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class KBBVehicleConfiguration:
+	year: str
+	make: str
+	model: str
+	style: str
+	style_url: str
+	cache_key: str
+	body_style: str | None = None
+	fuel_type: str | None = None
+	powertrain_type: str | None = None
+	drivetrain: str | None = None
+	extra: dict[str, Any] = field(default_factory=dict, repr=False)
+
+	@classmethod
+	def from_dict(cls, value: Mapping[str, Any]) -> Self:
+		known = {"year", "make", "model", "style", "style_url", "cache_key", "body_style", "fuel_type", "powertrain_type", "drivetrain"}
+		return cls(
+			year=str(value.get("year") or ""), make=str(value.get("make") or ""),
+			model=str(value.get("model") or ""), style=str(value.get("style") or ""),
+			style_url=str(value.get("style_url") or ""),
+			cache_key=str(value.get("cache_key") or ""),
+			body_style=_string(value.get("body_style")), fuel_type=_string(value.get("fuel_type")),
+			powertrain_type=_string(value.get("powertrain_type")), drivetrain=_string(value.get("drivetrain")),
+			extra={key: item for key, item in value.items() if key not in known},
+		)
+
+	def to_dict(self) -> dict[str, Any]:
+		return {**self.extra, "year": self.year, "make": self.make, "model": self.model, "style": self.style, "style_url": self.style_url, "body_style": self.body_style, "fuel_type": self.fuel_type, "powertrain_type": self.powertrain_type, "drivetrain": self.drivetrain, "cache_key": self.cache_key}
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class KBBVinResolution:
+	configuration: str | None
+	timestamp: datetime | None = None
+	status: str | None = None
+	extra: dict[str, Any] = field(default_factory=dict, repr=False)
+
+	@classmethod
+	def from_dict(cls, value: Mapping[str, Any]) -> Self:
+		return cls(
+			configuration=_string(value.get("configuration")),
+			timestamp=_datetime(value.get("timestamp")),
+			status=_string(value.get("status")),
+			extra={key: item for key, item in value.items() if key not in {"configuration", "timestamp", "status"}},
+		)
+
+	def to_dict(self) -> dict[str, Any]:
+		return {**self.extra, "configuration": self.configuration, "timestamp": _isoformat(self.timestamp), "status": self.status}
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class KBBNationalRow:
+	trim: str
+	msrp: str | None
+	fpp_natl: str | None
+	source: str
+	trim_source: str | None
+	timestamp: str
+
+	@classmethod
+	def from_legacy(cls, value: Any) -> Self:
+		if not isinstance(value, (list, tuple)) or len(value) != 6:
+			raise ValueError("KBB national row must contain six values")
+		return cls(
+			trim=str(value[0]), msrp=_string(value[1]), fpp_natl=_string(value[2]),
+			source=str(value[3]), trim_source=_string(value[4]), timestamp=str(value[5]),
+		)
+
+	def to_legacy(self) -> list[str | None]:
+		return [self.trim, self.msrp, self.fpp_natl, self.source, self.trim_source, self.timestamp]
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class KBBNationalTable:
+	timestamp: datetime
+	rows: tuple[KBBNationalRow, ...] = ()
+
+	@classmethod
+	def from_dict(cls, value: Mapping[str, Any]) -> Self:
+		timestamp = _datetime(value.get("timestamp"))
+		if timestamp is None:
+			raise ValueError("KBB national table timestamp is required")
+		rows = value.get("rows")
+		if not isinstance(rows, list):
+			raise ValueError("KBB national table rows must be an array")
+		return cls(timestamp=timestamp, rows=tuple(KBBNationalRow.from_legacy(row) for row in rows))
+
+	def to_dict(self) -> dict[str, Any]:
+		return {"timestamp": self.timestamp.isoformat(), "rows": [row.to_legacy() for row in self.rows]}
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class KBBLookupStatus:
+	state: KBBLookupState
+	checked_at: datetime
+	reason: str | None = None
+
+	@classmethod
+	def from_dict(cls, value: Mapping[str, Any]) -> Self:
+		checked_at = _datetime(value.get("checked_at"))
+		if checked_at is None:
+			raise ValueError("KBB lookup checked_at is required")
+		return cls(
+			state=KBBLookupState(str(value["status"])), checked_at=checked_at,
+			reason=_string(value.get("reason")),
+		)
+
+	def to_dict(self) -> dict[str, Any]:
+		result = {"status": self.state.value, "checked_at": self.checked_at.isoformat()}
+		if self.reason is not None:
+			result["reason"] = self.reason
+		return result
+
+
+@dataclass(kw_only=True, slots=True)
+class KBBPricingCache:
+	entries: dict[str, KBBPricingEntry] = field(default_factory=dict)
+	level23_entries: dict[str, KBBPricingEntry] = field(default_factory=dict)
+	configurations: dict[str, KBBVehicleConfiguration] = field(default_factory=dict)
+	vin_resolutions: dict[str, KBBVinResolution] = field(default_factory=dict)
+	national_tables: dict[str, KBBNationalTable] = field(default_factory=dict)
+	pricing_lookups: dict[str, KBBLookupStatus] = field(default_factory=dict)
+	extra: dict[str, Any] = field(default_factory=dict, repr=False)
+
+	@classmethod
+	def from_dict(cls, value: Mapping[str, Any]) -> Self:
+		known = {"entries", "level23_entries", "configurations", "vin_resolutions", "level23_national_tables", "pricing_lookups"}
+		return cls(
+			entries=_models(value.get("entries"), KBBPricingEntry.from_dict),
+			level23_entries=_models(value.get("level23_entries"), KBBPricingEntry.from_dict),
+			configurations=_models(value.get("configurations"), KBBVehicleConfiguration.from_dict),
+			vin_resolutions=_models(value.get("vin_resolutions"), KBBVinResolution.from_dict),
+			national_tables=_models(value.get("level23_national_tables"), KBBNationalTable.from_dict),
+			pricing_lookups=_models(value.get("pricing_lookups"), KBBLookupStatus.from_dict),
+			extra={key: item for key, item in value.items() if key not in known},
+		)
+
+	def to_dict(self) -> dict[str, Any]:
+		return {
+			**self.extra,
+			"entries": {key: item.to_dict() for key, item in self.entries.items()},
+			"level23_entries": {key: item.to_dict() for key, item in self.level23_entries.items()},
+			"configurations": {key: item.to_dict() for key, item in self.configurations.items()},
+			"vin_resolutions": {key: item.to_dict() for key, item in self.vin_resolutions.items()},
+			"level23_national_tables": {key: item.to_dict() for key, item in self.national_tables.items()},
+			"pricing_lookups": {key: item.to_dict() for key, item in self.pricing_lookups.items()},
+		}
+
+
+def _models(value: Any, factory: Any) -> dict[str, Any]:
+	if not isinstance(value, Mapping):
+		return {}
+	return {str(key): factory(item) for key, item in value.items() if isinstance(item, Mapping)}
+
+
+def _string(value: Any) -> str | None:
+	return str(value) if value is not None else None
+
+
+def _number(value: Any) -> Number | None:
+	return value if isinstance(value, (int, float)) and not isinstance(value, bool) else None
+
+
+def _datetime(value: Any) -> datetime | None:
+	if value is None:
+		return None
+	try:
+		return datetime.fromisoformat(str(value))
+	except ValueError:
+		return None
+
+
+def _isoformat(value: datetime | None) -> str | None:
+	return value.isoformat() if value else None

--- a/deal_lens/models/listing.py
+++ b/deal_lens/models/listing.py
@@ -1,0 +1,312 @@
+"""Source-independent listing model used by the DealLens pipeline."""
+
+from collections.abc import Iterator, Mapping, MutableMapping
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+from enum import StrEnum
+from typing import Any
+
+
+class ListingCondition(StrEnum):
+	NEW = "New"
+	USED = "Used"
+	CERTIFIED = "Certified"
+
+
+@dataclass(kw_only=True, slots=True)
+class Seller:
+	id: str | None = None
+	name: str | None = None
+	phone: str | None = None
+	stock_number: str | None = None
+	location: str | None = None
+	city: str | None = None
+	state: str | None = None
+	postal_code: str | None = None
+	latitude: float | None = None
+	longitude: float | None = None
+	dealer_fees: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass(kw_only=True, slots=True)
+class Vehicle:
+	vin: str | None = None
+	year: int | None = None
+	make: str | None = None
+	model: str | None = None
+	trim: str | None = None
+	trim_version: str | None = None
+	body_style: str | None = None
+	drivetrain: str | None = None
+	fuel_type: str | None = None
+	powertrain_type: str | None = None
+	transmission: str | None = None
+	engine: str | None = None
+	exterior_color: str | None = None
+	interior_color: str | None = None
+	specs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(kw_only=True, slots=True)
+class ListingDocuments:
+	carfax_url: str | None = None
+	autocheck_url: str | None = None
+	window_sticker_url: str | None = None
+	window_sticker_verified: bool | None = None
+
+
+@dataclass(kw_only=True, slots=True, eq=False)
+class Listing(MutableMapping[str, Any]):
+	"""Canonical listing facts with a compatibility mapping during migration.
+
+	Calculated analysis results deliberately do not live on this model. ``extra``
+	retains legacy fields so old saved records can cross the new boundary without
+	losing information.
+	"""
+
+	id: str
+	vehicle: Vehicle = field(default_factory=Vehicle)
+	condition: ListingCondition | None = None
+	price: Decimal | None = None
+	msrp: Decimal | None = None
+	mileage: int | None = None
+	days_on_market: int | None = None
+	listed_at: datetime | str | None = None
+	listing_url: str | None = None
+	seller: Seller = field(default_factory=Seller)
+	documents: ListingDocuments = field(default_factory=ListingDocuments)
+	images: list[str] = field(default_factory=list)
+	installed_options: list[dict[str, Any]] | None = None
+	installed_options_total: Decimal | None = None
+	price_history: list[dict[str, Any]] | None = None
+	warranty_coverages: list[dict[str, Any]] = field(default_factory=list)
+	source: str = "legacy"
+	source_record_id: str | None = None
+	provenance: dict[str, Any] = field(default_factory=dict)
+	warnings: list[dict[str, Any]] = field(default_factory=list)
+	raw_source: dict[str, Any] = field(default_factory=dict, repr=False)
+	extra: dict[str, Any] = field(default_factory=dict, repr=False)
+
+	@property
+	def vin(self) -> str | None:
+		return self.vehicle.vin
+
+	@property
+	def year(self) -> int | None:
+		return self.vehicle.year
+
+	@property
+	def title(self) -> str | None:
+		existing = self.extra.get("title")
+		if existing:
+			return str(existing)
+		parts = (self.year, self.vehicle.make, self.vehicle.model, self.vehicle.trim)
+		result = " ".join(str(value) for value in parts if value is not None)
+		return result or None
+
+	def to_legacy_dict(self) -> dict[str, Any]:
+		"""Serialize to the established saved-data and analysis envelope."""
+		result = dict(self.extra)
+		result.update({
+			"id": self.id,
+			"vin": self.vin,
+			"title": self.title,
+			"year": self.year,
+			"trim": self.vehicle.trim,
+			"condition": self.condition.value if self.condition else None,
+			"msrp": _json_number(self.msrp),
+			"price": _json_number(self.price),
+			"mileage": self.mileage,
+			"days_on_market": self.days_on_market,
+			"listed_at": _date_value(self.listed_at),
+			"listed": _date_value(self.listed_at),
+			"listing_url": self.listing_url,
+			"images": list(self.images),
+			"seller": _seller_dict(self.seller),
+			"specs": dict(self.vehicle.specs),
+			"installed_addons": {
+				"items": self.installed_options,
+				"total": _json_number(self.installed_options_total),
+			},
+			"price_history": self.price_history,
+			"additional_docs": {
+				"carfax_url": self.documents.carfax_url,
+				"autocheck_url": self.documents.autocheck_url,
+				"window_sticker_url": self.documents.window_sticker_url,
+			},
+			"provenance": self.provenance,
+			"warnings": self.warnings,
+		})
+		if self.raw_source:
+			result["source_data"] = self.raw_source
+		if "warranty" not in result:
+			result["warranty"] = (
+				{"coverages": self.warranty_coverages}
+				if self.warranty_coverages else None
+			)
+		return result
+
+	def __getitem__(self, key: str) -> Any:
+		return self.to_legacy_dict()[key]
+
+	def __iter__(self) -> Iterator[str]:
+		return iter(self.to_legacy_dict())
+
+	def __len__(self) -> int:
+		return len(self.to_legacy_dict())
+
+	def __setitem__(self, key: str, value: Any) -> None:
+		if key == "price":
+			self.price = _decimal(value)
+		elif key == "msrp":
+			self.msrp = _decimal(value)
+		elif key == "mileage":
+			self.mileage = _integer(value)
+		elif key == "days_on_market":
+			self.days_on_market = _integer(value)
+		else:
+			self.extra[key] = value
+
+	def __delitem__(self, key: str) -> None:
+		if key not in self.extra:
+			raise KeyError(key)
+		del self.extra[key]
+
+	def __eq__(self, other: object) -> bool:
+		if isinstance(other, Listing):
+			return self.to_legacy_dict() == other.to_legacy_dict()
+		if isinstance(other, Mapping):
+			ours = self.to_legacy_dict()
+			return all(ours.get(key) == value for key, value in other.items())
+		return NotImplemented
+
+	@classmethod
+	def from_legacy(cls, value: Mapping[str, Any]) -> "Listing":
+		return listing_from_legacy(value)
+
+
+def listing_from_legacy(value: Mapping[str, Any]) -> Listing:
+	"""Adapt legacy scraper/API envelopes without inventing missing values."""
+	data = dict(value)
+	specs = _dict(data.get("specs"))
+	seller_data = _dict(data.get("seller"))
+	documents = _dict(data.get("additional_docs"))
+	source_data = _dict(data.get("source_data"))
+	search_source = _dict(source_data.get("search_listing"))
+	detail_source = _dict(source_data.get("detail_listing"))
+	vehicle_source = _dict(detail_source.get("vehicle"))
+	build_source = _dict(vehicle_source.get("build"))
+	metadata_vehicle = _dict(_dict(data.get("metadata")).get("vehicle"))
+	warranty = _dict(data.get("warranty"))
+	condition_value = data.get("condition")
+	try:
+		condition = ListingCondition(str(condition_value)) if condition_value else None
+	except ValueError:
+		condition = None
+	known = {
+		"id", "vin", "year", "trim", "condition", "msrp", "price",
+		"mileage", "days_on_market", "listed", "listed_at", "listing_url",
+		"images", "seller", "specs", "installed_addons", "price_history",
+		"additional_docs", "source_data", "provenance", "warnings",
+	}
+	addons = _dict(data.get("installed_addons"))
+	return Listing(
+		id=str(data.get("id") or data.get("vin") or ""),
+		vehicle=Vehicle(
+			vin=_string(data.get("vin")),
+			year=_integer(data.get("year")),
+			make=_string(build_source.get("make") or detail_source.get("make") or search_source.get("make") or metadata_vehicle.get("make")),
+			model=_string(build_source.get("model") or detail_source.get("model") or search_source.get("model") or metadata_vehicle.get("model")),
+			trim=_string(data.get("trim")),
+			trim_version=_string(specs.get("Trim Version") or data.get("trim_version")),
+			body_style=_string(specs.get("Body Style") or data.get("body_style")),
+			drivetrain=_string(specs.get("Drivetrain")),
+			fuel_type=_string(specs.get("Fuel Type") or data.get("fuel_type")),
+			powertrain_type=_string(specs.get("Powertrain Type") or data.get("powertrain_type")),
+			transmission=_string(specs.get("Transmission")),
+			engine=_string(specs.get("Engine")),
+			exterior_color=_string(specs.get("Exterior Color")),
+			interior_color=_string(specs.get("Interior Color")),
+			specs=specs,
+		),
+		condition=condition,
+		price=_decimal(data.get("price")),
+		msrp=_decimal(data.get("msrp")),
+		mileage=_integer(data.get("mileage")),
+		days_on_market=_integer(data.get("days_on_market")),
+		listed_at=data.get("listed_at") or data.get("listed"),
+		listing_url=_string(data.get("listing_url")),
+		seller=Seller(
+			id=_string(seller_data.get("id")),
+			name=_string(seller_data.get("name")),
+			phone=_string(seller_data.get("phone")),
+			stock_number=_string(seller_data.get("stock_number")),
+			location=_string(seller_data.get("location")),
+			dealer_fees=list(seller_data.get("dealer_fees") or []),
+		),
+		documents=ListingDocuments(
+			carfax_url=_string(documents.get("carfax_url")),
+			autocheck_url=_string(documents.get("autocheck_url")),
+			window_sticker_url=_string(documents.get("window_sticker_url")),
+		),
+		images=list(data.get("images") or []),
+		installed_options=addons.get("items"),
+		installed_options_total=_decimal(addons.get("total")),
+		price_history=data.get("price_history"),
+		warranty_coverages=list(warranty.get("coverages") or []),
+		source=str(source_data.get("provider") or "legacy"),
+		source_record_id=str(data.get("id")) if data.get("id") is not None else None,
+		provenance=_dict(data.get("provenance")),
+		warnings=list(data.get("warnings") or []),
+		raw_source=source_data,
+		extra={key: item for key, item in data.items() if key not in known},
+	)
+
+
+def _dict(value: Any) -> dict[str, Any]:
+	return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _string(value: Any) -> str | None:
+	return str(value) if value is not None else None
+
+
+def _integer(value: Any) -> int | None:
+	if value is None or isinstance(value, bool):
+		return None
+	try:
+		return int(value)
+	except (TypeError, ValueError):
+		return None
+
+
+def _decimal(value: Any) -> Decimal | None:
+	if value is None or isinstance(value, bool):
+		return None
+	try:
+		return Decimal(str(value))
+	except (InvalidOperation, ValueError):
+		return None
+
+
+def _json_number(value: Decimal | None) -> int | float | None:
+	if value is None:
+		return None
+	return int(value) if value == value.to_integral_value() else float(value)
+
+
+def _date_value(value: datetime | str | None) -> str | None:
+	return value.isoformat() if isinstance(value, datetime) else value
+
+
+def _seller_dict(value: Seller) -> dict[str, Any]:
+	result: dict[str, Any] = {
+		"name": value.name,
+		"location": value.location,
+		"phone": value.phone,
+		"stock_number": value.stock_number,
+	}
+	if value.dealer_fees:
+		result["dealer_fees"] = value.dealer_fees
+	return result

--- a/tests/unit/test_domain_models.py
+++ b/tests/unit/test_domain_models.py
@@ -1,0 +1,136 @@
+import json
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from deal_lens.models import (
+	DataWarning,
+	DealerFee,
+	KBBNationalTable,
+	KBBPricingBasis,
+	KBBPricingCache,
+	ListingDataset,
+	ResourceState,
+	SupplementaryResourceStatus,
+)
+
+
+def test_kbb_pricing_cache_models_incomplete_and_empty_results():
+	now = datetime.now().isoformat()
+	payload = {
+		"level23_entries": {
+			"entry": {
+				"model": "F150 SuperCrew Cab",
+				"kbb_trim": "entry",
+				"fpp_local": 44_880,
+				"pricing_basis": "vin",
+				"provider_note": "preserved",
+			},
+		},
+		"configurations": {
+			"fingerprint": {
+				"year": "2025", "make": "Ford", "model": "F150 SuperCrew Cab",
+				"style": "XLT Pickup 4D", "style_url": "https://kbb.example/style",
+				"cache_key": "entry",
+			},
+		},
+		"vin_resolutions": {
+			"VIN": {"configuration": "fingerprint", "timestamp": now},
+		},
+		"level23_national_tables": {
+			"2025 Ford F150 SuperCrew Cab": {"timestamp": now, "rows": []},
+		},
+		"pricing_lookups": {
+			"2025 Ford F150 SuperCrew Cab": {"status": "complete", "checked_at": now},
+		},
+		"future_section": {"kept": True},
+	}
+
+	cache = KBBPricingCache.from_dict(payload)
+
+	assert cache.level23_entries["entry"].pricing_basis is KBBPricingBasis.VIN
+	assert cache.level23_entries["entry"].msrp is None
+	assert cache.level23_entries["entry"].extra["provider_note"] == "preserved"
+	assert cache.national_tables["2025 Ford F150 SuperCrew Cab"].rows == ()
+	serialized = cache.to_dict()
+	assert serialized["level23_national_tables"]["2025 Ford F150 SuperCrew Cab"]["rows"] == []
+	assert serialized["future_section"] == {"kept": True}
+
+
+def test_kbb_national_table_rejects_missing_timestamp():
+	try:
+		KBBNationalTable.from_dict({"rows": []})
+	except ValueError as error:
+		assert "timestamp" in str(error)
+	else:
+		raise AssertionError("missing timestamp should be rejected")
+
+
+def test_supplementary_resource_status_round_trips_retry_state():
+	attempted = datetime.now()
+	status = SupplementaryResourceStatus(
+		state=ResourceState.FAILED,
+		source_url="https://images.example/vehicle.jpg",
+		attempted_at=attempted,
+		retry_after=attempted + timedelta(days=1),
+		failure_reason="http_error",
+		http_status=403,
+	)
+
+	restored = SupplementaryResourceStatus.from_dict(status.to_dict())
+
+	assert restored == status
+
+
+def test_dealer_fee_accepts_legacy_tuple_and_mapping():
+	legacy = DealerFee.from_legacy(("Documentation fee", 599, False, "Dealer fee"))
+	mapping = DealerFee.from_legacy({"name": "Delivery", "amount": 250, "included": True})
+
+	assert legacy.to_legacy() == ("Documentation fee", 599.0, False, "Dealer fee")
+	assert mapping.amount == 250
+	assert mapping.included is True
+
+
+def test_data_warning_preserves_provider_specific_fields():
+	warning = DataWarning.from_dict({
+		"code": "missing_data", "field": "price", "message": "missing",
+		"source": "visor_api", "api_path": "price", "received_type": "null",
+	})
+
+	assert warning.source_path == "price"
+	assert warning.to_dict()["received_type"] == "null"
+
+
+def test_listing_dataset_loads_recorded_shape_and_round_trips_unknown_sections():
+	fixture = Path(__file__).parents[2] / "output" / "example_output.json"
+	payload = json.loads(fixture.read_text(encoding="utf-8"))
+	# The small historical example predates runtime metadata; supply the required
+	# boundary field while retaining every original section.
+	payload.setdefault("metadata", {}).setdefault("runtime", {"timestamp": "example"})
+	payload["future_section"] = {"schema": 2}
+
+	dataset = ListingDataset.from_dict(payload)
+	serialized = dataset.to_dict()
+
+	assert len(dataset.listings) == len(payload["listings"])
+	assert serialized["future_section"] == {"schema": 2}
+	assert serialized["metadata"]["runtime"]["timestamp"] == payload["metadata"]["runtime"]["timestamp"]
+
+
+def test_kbb_cache_preserves_unavailable_vin_resolution():
+	payload = {
+		"vin_resolutions": {
+			"VIN": {
+				"configuration": None,
+				"status": "unavailable",
+				"timestamp": datetime.now().isoformat(),
+			},
+		},
+	}
+
+	cache = KBBPricingCache.from_dict(payload)
+	resolution = cache.vin_resolutions["VIN"]
+
+	assert resolution.configuration is None
+	assert resolution.status == "unavailable"
+	assert cache.to_dict()["vin_resolutions"]["VIN"]["status"] == "unavailable"

--- a/tests/unit/test_kbb.py
+++ b/tests/unit/test_kbb.py
@@ -1,5 +1,6 @@
 import asyncio
 
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 from contextlib import nullcontext
 
@@ -487,6 +488,67 @@ async def test_vin_first_new_listing_uses_resolved_body_specific_style(
 		"https://kbb.com/honda/civic/2025/sport-hatchback-4d/"
 	)
 	assert cache["vin_resolutions"]["19XFL2H80SE034568"]
+
+
+async def test_complete_vin_first_cache_does_not_start_browser(monkeypatch):
+	listing = {
+		"id": "cached",
+		"vin": "CACHEDVIN",
+		"year": 2025,
+		"condition": "Used",
+		"trim": "XLT",
+	}
+	cache_key = "2025 Ford F150 SuperCrew Cab XLT Pickup 4D"
+	fingerprint = "cached-configuration"
+	cache = {
+		"level23_entries": {
+			cache_key: {
+				"model": "F150 SuperCrew Cab",
+				"kbb_trim": cache_key,
+				"msrp": 50_000,
+				"fpp_natl": 48_000,
+				"fmr_low": 42_000,
+				"fmr_high": 47_000,
+				"fpp_local": 45_000,
+				"fmv": 44_500,
+				"natl_source": "https://kbb.example/national",
+				"local_source": "https://kbb.example/local",
+			},
+		},
+		"configurations": {
+			fingerprint: {
+				"year": "2025",
+				"make": "Ford",
+				"model": "F150 SuperCrew Cab",
+				"style": "XLT Pickup 4D",
+				"cache_key": cache_key,
+			},
+		},
+		"vin_resolutions": {
+			"CACHEDVIN": {"configuration": fingerprint},
+		},
+		"level23_national_tables": {
+			"2025 Ford F150 SuperCrew Cab": {
+				"timestamp": datetime.now().isoformat(),
+				"rows": [],
+			},
+		},
+	}
+	create_browser = AsyncMock()
+	monkeypatch.setattr("analysis.kbb.create_kbb_browser", create_browser)
+	monkeypatch.setattr("analysis.kbb.is_local_fresh", lambda _entry: True)
+
+	valuations = await get_vin_first_pricing_data(
+		"Ford",
+		"F-150",
+		[listing],
+		{"2025 Ford F150 SuperCrew Cab": [listing]},
+		cache,
+	)
+
+	create_browser.assert_not_awaited()
+	assert listing["kbb_cache_key"] == cache_key
+	assert len(valuations) == 1
 
 
 def test_configuration_matching_treats_optional_evidence_as_constraints():

--- a/tests/unit/test_kbb.py
+++ b/tests/unit/test_kbb.py
@@ -551,6 +551,40 @@ async def test_complete_vin_first_cache_does_not_start_browser(monkeypatch):
 	assert len(valuations) == 1
 
 
+async def test_fresh_unavailable_vin_result_does_not_restart_browser(monkeypatch):
+	listing = {
+		"id": "unresolved",
+		"vin": "UNRESOLVEDVIN",
+		"year": 2025,
+		"condition": "Used",
+		"trim": "Unknown",
+	}
+	ymm = "2025 Ford F150 SuperCrew Cab"
+	cache = {
+		"level23_entries": {},
+		"configurations": {},
+		"vin_resolutions": {
+			"UNRESOLVEDVIN": {
+				"configuration": None,
+				"status": "unavailable",
+				"timestamp": datetime.now().isoformat(),
+			},
+		},
+		"level23_national_tables": {
+			ymm: {"timestamp": datetime.now().isoformat(), "rows": []},
+		},
+	}
+	create_browser = AsyncMock()
+	monkeypatch.setattr("analysis.kbb.create_kbb_browser", create_browser)
+
+	valuations = await get_vin_first_pricing_data(
+		"Ford", "F-150", [listing], {ymm: [listing]}, cache,
+	)
+
+	create_browser.assert_not_awaited()
+	assert valuations == []
+
+
 def test_configuration_matching_treats_optional_evidence_as_constraints():
 	configuration = {
 		"style": "SE Hatchback 4D",

--- a/tests/unit/test_listing_model.py
+++ b/tests/unit/test_listing_model.py
@@ -1,0 +1,78 @@
+from decimal import Decimal
+
+from deal_lens.models import ListingCondition, listing_from_legacy
+from visor_api.adapter import listing_from_visor
+
+
+def test_legacy_factory_preserves_source_facts_and_unknown_fields():
+	source = {
+		"id": "listing-1",
+		"vin": "TESTVIN",
+		"year": 2025,
+		"trim": "Limited",
+		"condition": "Used",
+		"price": 25_500,
+		"mileage": 12_345,
+		"custom_legacy_field": "preserved",
+		"source_data": {"provider": "legacy_scraper", "record": {"a": 1}},
+	}
+
+	listing = listing_from_legacy(source)
+
+	assert listing.id == "listing-1"
+	assert listing.vin == "TESTVIN"
+	assert listing.condition is ListingCondition.USED
+	assert listing.price == Decimal("25500")
+	assert listing.mileage == 12_345
+	assert listing.source == "legacy_scraper"
+	assert listing["custom_legacy_field"] == "preserved"
+	assert listing.to_legacy_dict()["source_data"] == source["source_data"]
+
+
+def test_missing_values_remain_unknown():
+	listing = listing_from_legacy({"id": "listing-1"})
+
+	assert listing.vin is None
+	assert listing.year is None
+	assert listing.price is None
+	assert listing.mileage is None
+	assert listing.condition is None
+
+
+def test_visor_factory_prefers_detail_and_retains_provenance():
+	listing = listing_from_visor(
+		{
+			"id": "listing-1",
+			"vin": "TESTVIN",
+			"year": 2024,
+			"make": "Example",
+			"model": "Car",
+			"price": 30_000,
+			"miles": 100,
+		},
+		{"id": "listing-1", "price": 29_000},
+	)
+
+	assert listing.price == Decimal("29000")
+	assert listing.vehicle.make == "Example"
+	assert listing.vehicle.model == "Car"
+	assert listing.source == "visor_api"
+	assert listing.raw_source["search_listing"]["price"] == 30_000
+	assert listing.provenance["price"] == {
+		"kind": "source_fact",
+		"api_path": "price",
+	}
+
+
+def test_legacy_serialization_uses_json_compatible_currency_values():
+	listing = listing_from_legacy({
+		"id": "listing-1",
+		"price": 25_500,
+		"msrp": 27_000.50,
+	})
+
+	serialized = listing.to_legacy_dict()
+
+	assert serialized["price"] == 25_500
+	assert serialized["msrp"] == 27_000.5
+	assert not isinstance(serialized["price"], Decimal)

--- a/utils/models.py
+++ b/utils/models.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Optional
 
+from deal_lens.models import Listing, listing_from_legacy
+
 from utils.constants import (
     BED_LENGTH_RE,
     BODY_STYLE_ALIASES,
@@ -609,15 +611,16 @@ class PricingAnchors:
 
 @dataclass
 class ListingContext:
-    listing_id: str
+    listing_id: str = ""
     vin: str = ""
     cache_key: str = ""
 
     year: str = ""
     base_trim: str = ""
 
-    listing: dict[str, Any] = field(default_factory=dict)
-    full_listing: dict[str, Any] = field(default_factory=dict)
+    # Any keeps transitional dict-oriented scoring/report call sites type-safe;
+    # __post_init__ guarantees the runtime value is the canonical Listing.
+    listing: Any = field(default_factory=dict)
 
     report_path: Optional[str] = None
     carfax: Any | None = None
@@ -631,6 +634,13 @@ class ListingContext:
     deal_rating: Optional[str] = None
     risk_score: Optional[int] = None
     narrative: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.listing, Listing):
+            self.listing = listing_from_legacy(self.listing)
+        self.listing_id = self.listing_id or self.listing.id
+        self.vin = self.vin or self.listing.vin or ""
+        self.year = self.year or str(self.listing.year or "")
 
 
 @dataclass

--- a/visor_api/__init__.py
+++ b/visor_api/__init__.py
@@ -7,7 +7,12 @@ from visor_api.client import (
 	VisorReadTimeoutError,
 	VisorTimeoutError,
 )
-from visor_api.adapter import adapt_facets_response, adapt_listing, adapt_search_response
+from visor_api.adapter import (
+	adapt_facets_response,
+	adapt_listing,
+	adapt_search_response,
+	listing_from_visor,
+)
 from visor_api.query import LISTING_EXPANSIONS, LISTING_FIELDS, VisorListingQuery
 from visor_api.level1_query import (
 	LEVEL1_FACETS,
@@ -123,5 +128,6 @@ __all__ = [
 	"VehicleBuild",
 	"adapt_facets_response",
 	"adapt_listing",
+	"listing_from_visor",
 	"adapt_search_response",
 ]

--- a/visor_api/adapter.py
+++ b/visor_api/adapter.py
@@ -5,6 +5,8 @@ from copy import deepcopy
 from datetime import datetime, timezone
 from typing import Any
 
+from deal_lens.models import Listing, listing_from_legacy
+
 from visor_api.models import APIModel
 
 
@@ -153,7 +155,7 @@ def _adapt_price_history(value: Any) -> list[dict[str, Any]] | None:
 	return result
 
 
-def adapt_listing(
+def _adapt_listing_legacy(
 	search_listing: Mapping[str, Any] | APIModel | None,
 	detail_listing: Mapping[str, Any] | APIModel | None = None,
 ) -> dict[str, Any]:
@@ -405,6 +407,24 @@ def adapt_listing(
 	return listing
 
 
+def listing_from_visor(
+	search_listing: Mapping[str, Any] | APIModel | None,
+	detail_listing: Mapping[str, Any] | APIModel | None = None,
+) -> Listing:
+	"""Build the stable DealLens listing model from Visor transport records."""
+	return listing_from_legacy(
+		_adapt_listing_legacy(search_listing, detail_listing)
+	)
+
+
+def adapt_listing(
+	search_listing: Mapping[str, Any] | APIModel | None,
+	detail_listing: Mapping[str, Any] | APIModel | None = None,
+) -> Listing:
+	"""Compatibility name for the Visor-to-domain adapter."""
+	return listing_from_visor(search_listing, detail_listing)
+
+
 def adapt_facets_response(
 	response: Mapping[str, Any] | APIModel,
 	*,
@@ -441,7 +461,8 @@ def adapt_search_response(
 	response_data = _mapping(response)
 	rows = _sequence(response_data.get("data")) or []
 	detail_by_id = details or {}
-	listings = [adapt_listing(_mapping(row), detail_by_id.get(str(_mapping(row).get("id")))) for row in rows]
+	listing_models = [adapt_listing(_mapping(row), detail_by_id.get(str(_mapping(row).get("id")))) for row in rows]
+	listings = [listing.to_legacy_dict() for listing in listing_models]
 	warnings = []
 	for listing in listings:
 		for listing_warning in listing.get("warnings", []):

--- a/visor_api/level2_service.py
+++ b/visor_api/level2_service.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Protocol
 
+from deal_lens.models import Listing, listing_from_legacy
 from utils.progress import NULL_PROGRESS, ProgressReporter
 from visor_api.adapter import adapt_listing
 from visor_api.client import QueryParams, VisorAPIError, VisorTimeoutError
@@ -41,7 +42,7 @@ class Level2ListingRecord:
 
 	listing_id: str
 	vin: str | None
-	listing: dict[str, Any]
+	listing: Listing | dict[str, Any]
 	search_record: dict[str, Any]
 	detail_record: dict[str, Any] | None
 	detail_error: str | None = None
@@ -50,7 +51,10 @@ class Level2ListingRecord:
 		return {
 			"listing_id": self.listing_id,
 			"vin": self.vin,
-			"listing": self.listing,
+			"listing": (
+				self.listing.to_legacy_dict()
+				if isinstance(self.listing, Listing) else self.listing
+			),
 			"search_record": self.search_record,
 			"detail_record": self.detail_record,
 			"detail_error": self.detail_error,
@@ -64,7 +68,7 @@ class Level2ListingRecord:
 		return cls(
 			listing_id=listing_id,
 			vin=_optional_string(value.get("vin")),
-			listing=_dictionary(value.get("listing"), "listing"),
+			listing=listing_from_legacy(_dictionary(value.get("listing"), "listing")),
 			search_record=_dictionary(value.get("search_record"), "search_record"),
 			detail_record=(
 				_dictionary(value.get("detail_record"), "detail_record")
@@ -206,13 +210,13 @@ def collect_level2_listings(
 		detail, detail_error = _collect_detail(client, listing_id)
 		adapted = adapt_listing(row, detail)
 		if detail_error is not None:
-			adapted.setdefault("warnings", []).append({
+			adapted.warnings.append({
 				"field": "detail",
 				"code": "source_error",
 				"message": "Listing detail could not be retrieved.",
 				"api_path": f"/v1/listings/{listing_id}",
 			})
-			adapted.setdefault("provenance", {})["detail"] = {
+			adapted.provenance["detail"] = {
 				"kind": "unavailable",
 				"reason": "source_error",
 			}


### PR DESCRIPTION
Added the following models:

- Core listing models:
  - Listing — Canonical source-independent vehicle listing passed through the DealLens pipeline.
  - ListingCondition — Controlled values for new, used, and certified listings.
  - Vehicle — Vehicle identity, configuration, drivetrain, and specification facts.
  - Seller — Dealer identity, contact, location, stock number, and fee information.
  - ListingDocuments — URLs and availability information for history reports and window stickers.
- Listing child models:
  - DealerFee — Normalized dealer fee with its amount, inclusion status, and description.
  - InstalledOption — Factory or dealer-installed option, including its code and price.
  - PriceHistoryRecord — One dated listing-price change with optional mileage.
  - WarrantyCoverage — One warranty category and its remaining time or mileage.
  - DataWarning — Structured warning for missing, malformed, or unavailable data.
  - SourceProvenance — Describes where a fact came from or how it was calculated.
- KBB models:
  - KBBPricingEntry — Canonical collection of national and local KBB pricing facts for one configuration.
  - KBBPricingBasis — Indicates whether pricing came from a new, used, VIN-specific, or national workflow.
  - KBBPricingCache — Typed aggregate for all persisted KBB pricing and lookup state.
  - KBBVehicleConfiguration — Canonical KBB style and configuration resolved for compatible vehicles.
  - KBBVinResolution — Associates a VIN with a resolved KBB configuration or an unavailable result.
  - KBBNationalRow — One trim row from a KBB national pricing table.
  - KBBNationalTable — Timestamped collection of national KBB trim rows, including successful empty results.
  - KBBLookupStatus — Records whether a KBB lookup completed or failed and when it was checked.
  - KBBLookupState — Controlled completion and failure states for KBB lookups.
- Supplementary-resource models:
  - SupplementaryResourceStatus — Attempt, failure, retry, and download state for one supplementary resource.
  - SupplementaryStatus — Groups image, sticker, dealer-data, and vehicle-history resource states.
  - ResourceState — Controlled values for available, unavailable, failed, and downloaded resources.
- Saved-dataset models:
  - ListingDataset — Complete persisted report input containing metadata and listings.
  - ListingDatasetMetadata — Search scope, runtime, warnings, source information, and market metadata.
  - DatasetVehicle — Make, model, trim, and year scope of a saved dataset.
  - DatasetRuntime — Collection timestamp, source URL, provider, and runtime-specific metadata.